### PR TITLE
Remove Arch constraints from base bundle

### DIFF
--- a/development/openstack-base-spaces/bundle.yaml
+++ b/development/openstack-base-spaces/bundle.yaml
@@ -1,12 +1,9 @@
 machines:
   '0':
-    constraints: arch=amd64
     series: xenial
   '1':
-    constraints: arch=amd64
     series: xenial
   '2':
-    constraints: arch=amd64
     series: xenial
 relations:
 - - nova-compute:amqp

--- a/development/openstack-base-trusty-mitaka/bundle.yaml
+++ b/development/openstack-base-trusty-mitaka/bundle.yaml
@@ -1,15 +1,11 @@
 machines:
   '0':
-    constraints: arch=amd64
     series: trusty
   '1':
-    constraints: arch=amd64
     series: trusty
   '2':
-    constraints: arch=amd64
     series: trusty
   '3':
-    constraints: arch=amd64
     series: trusty
 relations:
 - - nova-compute:amqp

--- a/development/openstack-base-xenial-mitaka/bundle.yaml
+++ b/development/openstack-base-xenial-mitaka/bundle.yaml
@@ -1,15 +1,11 @@
 machines:
   '0':
-    constraints: arch=amd64
     series: xenial
   '1':
-    constraints: arch=amd64
     series: xenial
   '2':
-    constraints: arch=amd64
     series: xenial
   '3':
-    constraints: arch=amd64
     series: xenial
 relations:
 - - nova-compute:amqp

--- a/stable/openstack-base/bundle.yaml
+++ b/stable/openstack-base/bundle.yaml
@@ -1,15 +1,11 @@
 machines:
   '0':
-    constraints: arch=amd64
     series: xenial
   '1':
-    constraints: arch=amd64
     series: xenial
   '2':
-    constraints: arch=amd64
     series: xenial
   '3':
-    constraints: arch=amd64
     series: xenial
 relations:
 - - nova-compute:amqp


### PR DESCRIPTION
There is no reason to have arch constraints in the base bundles
other than to make arch != amd64 fail for no reason so lets
remove that constraint. closes #8