### PR TITLE
Support arm64

### DIFF
--- a/development/openstack-base-spaces/bundle.yaml
+++ b/development/openstack-base-spaces/bundle.yaml
@@ -1,12 +1,9 @@
 machines:
   '0':
-    constraints: arch=amd64
     series: xenial
   '1':
-    constraints: arch=amd64
     series: xenial
   '2':
-    constraints: arch=amd64
     series: xenial
 relations:
 - - nova-compute:amqp

--- a/development/openstack-base-trusty-mitaka/bundle.yaml
+++ b/development/openstack-base-trusty-mitaka/bundle.yaml
@@ -1,15 +1,11 @@
 machines:
   '0':
-    constraints: arch=amd64
     series: trusty
   '1':
-    constraints: arch=amd64
     series: trusty
   '2':
-    constraints: arch=amd64
     series: trusty
   '3':
-    constraints: arch=amd64
     series: trusty
 relations:
 - - nova-compute:amqp

--- a/development/openstack-base-xenial-mitaka/bundle.yaml
+++ b/development/openstack-base-xenial-mitaka/bundle.yaml
@@ -1,15 +1,11 @@
 machines:
   '0':
-    constraints: arch=amd64
     series: xenial
   '1':
-    constraints: arch=amd64
     series: xenial
   '2':
-    constraints: arch=amd64
     series: xenial
   '3':
-    constraints: arch=amd64
     series: xenial
 relations:
 - - nova-compute:amqp

--- a/development/openstack-dpdk/bundle.yaml
+++ b/development/openstack-dpdk/bundle.yaml
@@ -1,12 +1,12 @@
 machines:
   '0':
-    constraints: arch=amd64 tags=netspaces
+    tags=netspaces
     series: xenial
   '1':
-    constraints: arch=amd64 tags=dpdk
+    tags=dpdk
     series: xenial
   '2':
-    constraints: arch=amd64 tags=netspaces
+    tags=netspaces
     series: xenial
 relations:
 - - nova-compute:amqp

--- a/development/openstack-lxd/bundle.yaml
+++ b/development/openstack-lxd/bundle.yaml
@@ -1,15 +1,11 @@
 machines:
   '0':
-    constraints: arch=amd64
     series: xenial
   '1':
-    constraints: arch=amd64
     series: xenial
   '2':
-    constraints: arch=amd64
     series: xenial
   '3':
-    constraints: arch=amd64
     series: xenial
 relations:
 - - nova-compute:amqp

--- a/stable/openstack-base/bundle.yaml
+++ b/stable/openstack-base/bundle.yaml
@@ -1,15 +1,11 @@
 machines:
   '0':
-    constraints: arch=amd64
     series: xenial
   '1':
-    constraints: arch=amd64
     series: xenial
   '2':
-    constraints: arch=amd64
     series: xenial
   '3':
-    constraints: arch=amd64
     series: xenial
 relations:
 - - nova-compute:amqp

--- a/stable/openstack-base/bundle.yaml
+++ b/stable/openstack-base/bundle.yaml
@@ -211,7 +211,7 @@ services:
     annotations:
       gui-x: '250'
       gui-y: '250'
-    charm: cs:xenial/nova-compute-259
+    charm: cs:xenial/nova-compute-262
     num_units: 3
     options:
       openstack-origin: cloud:xenial-newton

--- a/stable/openstack-lxd/bundle.yaml
+++ b/stable/openstack-lxd/bundle.yaml
@@ -1,15 +1,11 @@
 machines:
   '0':
-    constraints: arch=amd64
     series: xenial
   '1':
-    constraints: arch=amd64
     series: xenial
   '2':
-    constraints: arch=amd64
     series: xenial
   '3':
-    constraints: arch=amd64
     series: xenial
 relations:
 - - nova-compute:amqp

--- a/stable/openstack-lxd/bundle.yaml
+++ b/stable/openstack-lxd/bundle.yaml
@@ -190,7 +190,7 @@ services:
     annotations:
       gui-x: '250'
       gui-y: '250'
-    charm: cs:xenial/nova-compute-259
+    charm: cs:xenial/nova-compute-262
     num_units: 3
     options:
       openstack-origin: cloud:xenial-newton

--- a/stable/openstack-telemetry/bundle.yaml
+++ b/stable/openstack-telemetry/bundle.yaml
@@ -1,15 +1,11 @@
 machines:
   '0':
-    constraints: arch=amd64
     series: xenial
   '1':
-    constraints: arch=amd64
     series: xenial
   '2':
-    constraints: arch=amd64
     series: xenial
   '3':
-    constraints: arch=amd64
     series: xenial
 relations:
 - - nova-compute:amqp

--- a/stable/openstack-telemetry/bundle.yaml
+++ b/stable/openstack-telemetry/bundle.yaml
@@ -262,7 +262,7 @@ services:
     annotations:
       gui-x: '250'
       gui-y: '250'
-    charm: cs:xenial/nova-compute-259
+    charm: cs:xenial/nova-compute-262
     num_units: 3
     options:
       openstack-origin: cloud:xenial-newton


### PR DESCRIPTION
Remove the arch constraint blocking deployment on arm64, and update nova-compute charm to a version that supports EFI VMs by default on arm64.