### PR TITLE
Add ceph-access relation between nova-compute and cinder-ceph

### DIFF
--- a/development/openstack-base-xenial-ocata/bundle.yaml
+++ b/development/openstack-base-xenial-ocata/bundle.yaml
@@ -64,6 +64,8 @@ relations:
   - cinder:storage-backend
 - - ceph-mon:client
   - nova-compute:ceph
+- - nova-compute:ceph-access
+  - cinder-ceph:ceph-access
 - - cinder:shared-db
   - mysql:shared-db
 - - ceph-mon:client


### PR DESCRIPTION
This is required for OpenStack Ocata and beyond to support Boot From
Volume.

References:
0: https://github.com/openstack/nova/commit/b89efa3ef611a1932df0c2d6e6f30315b5111a57
1: https://bugs.launchpad.net/bugs/1671422

Fixes #31