### PR TITLE
Add ceph-access relation between nova-compute and cinder-ceph for stable

### DIFF
--- a/stable/openstack-base/bundle.yaml
+++ b/stable/openstack-base/bundle.yaml
@@ -64,6 +64,8 @@ relations:
   - cinder:storage-backend
 - - ceph-mon:client
   - nova-compute:ceph
+- - nova-compute:ceph-access
+  - cinder-ceph:ceph-access
 - - cinder:shared-db
   - mysql:shared-db
 - - ceph-mon:client


### PR DESCRIPTION
This is required for OpenStack Ocata and beyond to support Boot From
Volume.

References:
0: openstack/nova@b89efa3
1: https://bugs.launchpad.net/bugs/1671422