### PR TITLE
Add instructions for importing arm64 cloud images

### DIFF
--- a/development/openstack-base-spaces/README.md
+++ b/development/openstack-base-spaces/README.md
@@ -88,6 +88,16 @@ In order to run instances on your cloud, you'll need to upload an image to boot 
         --container-format=bare --disk-format=qcow2 \
         < ~/images/trusty-server-cloudimg-amd64-disk1.img
 
+**Note:** for ARM 64-bit (arm64) guests, you will also need to configure the image to boot in UEFI mode:
+
+    mkdir -p ~/images
+    wget -O ~/images/trusty-server-cloudimg-arm64-uefi1.img \
+        http://cloud-images.ubuntu.com/trusty/current/trusty-server-cloudimg-arm64-uefi1.img
+    glance image-create --name="trusty" --visibility public --progress \
+        --container-format=bare --disk-format=qcow2 \
+        --property="hw_firmware_type=uefi" \
+        < ~/images/trusty-server-cloudimg-arm64-uefi1.img
+
 ### Configure networking
 
 For the purposes of a quick test, we'll setup an 'external' network and shared router ('provider-router') which will be used by all tenants for public access to instances:

--- a/development/openstack-base-xenial-mitaka/README.md
+++ b/development/openstack-base-xenial-mitaka/README.md
@@ -80,6 +80,11 @@ In order to run instances on your cloud, you'll need to upload an image to boot 
 
 Images for other architectures can be obtained from [Ubuntu Cloud Images][].  Be sure to use the appropriate image for the cpu architecture.
 
+**Note:** for ARM 64-bit (arm64) guests, you will also need to configure the image to boot in UEFI mode:
+
+    curl http://cloud-images.ubuntu.com/xenial/current/xenial-server-cloudimg-arm64-uefi1.img | \
+        openstack image create --public --container-format=bare --disk-format=qcow2 --property hw_firmware_type=uefi xenial
+
 ### Configure networking
 
 For the purposes of a quick test, we'll setup an 'external' network and shared router ('provider-router') which will be used by all tenants for public access to instances:

--- a/development/openstack-base-xenial-newton/README.md
+++ b/development/openstack-base-xenial-newton/README.md
@@ -80,6 +80,11 @@ In order to run instances on your cloud, you'll need to upload an image to boot 
 
 Images for other architectures can be obtained from [Ubuntu Cloud Images][].  Be sure to use the appropriate image for the cpu architecture.
 
+**Note:** for ARM 64-bit (arm64) guests, you will also need to configure the image to boot in UEFI mode:
+
+    curl http://cloud-images.ubuntu.com/xenial/current/xenial-server-cloudimg-arm64-uefi1.img | \
+        openstack image create --public --container-format=bare --disk-format=qcow2 --property hw_firmware_type=uefi xenial
+
 ### Configure networking
 
 For the purposes of a quick test, we'll setup an 'external' network and shared router ('provider-router') which will be used by all tenants for public access to instances:

--- a/development/openstack-base-xenial-ocata/README.md
+++ b/development/openstack-base-xenial-ocata/README.md
@@ -80,6 +80,11 @@ In order to run instances on your cloud, you'll need to upload an image to boot 
 
 Images for other architectures can be obtained from [Ubuntu Cloud Images][].  Be sure to use the appropriate image for the cpu architecture.
 
+**Note:** for ARM 64-bit (arm64) guests, you will also need to configure the image to boot in UEFI mode:
+
+    curl http://cloud-images.ubuntu.com/xenial/current/xenial-server-cloudimg-arm64-uefi1.img | \
+        openstack image create --public --container-format=bare --disk-format=qcow2 --property hw_firmware_type=uefi xenial
+
 ### Configure networking
 
 For the purposes of a quick test, we'll setup an 'external' network and shared router ('provider-router') which will be used by all tenants for public access to instances:

--- a/development/openstack-base-xenial-pike/README.md
+++ b/development/openstack-base-xenial-pike/README.md
@@ -80,6 +80,11 @@ In order to run instances on your cloud, you'll need to upload an image to boot 
 
 Images for other architectures can be obtained from [Ubuntu Cloud Images][].  Be sure to use the appropriate image for the cpu architecture.
 
+**Note:** for ARM 64-bit (arm64) guests, you will also need to configure the image to boot in UEFI mode:
+
+    curl http://cloud-images.ubuntu.com/xenial/current/xenial-server-cloudimg-arm64-uefi1.img | \
+        openstack image create --public --container-format=bare --disk-format=qcow2 --property hw_firmware_type=uefi xenial
+
 ### Configure networking
 
 For the purposes of a quick test, we'll setup an 'external' network and shared router ('provider-router') which will be used by all tenants for public access to instances:

--- a/stable/openstack-base/README.md
+++ b/stable/openstack-base/README.md
@@ -78,6 +78,11 @@ In order to run instances on your cloud, you'll need to upload an image to boot 
     curl http://cloud-images.ubuntu.com/xenial/current/xenial-server-cloudimg-amd64-disk1.img | \
         openstack image create --public --container-format=bare --disk-format=qcow2 xenial
 
+**Note:** for ARM 64-bit (arm64) guests, you will also need to configure the image to boot in UEFI mode:
+
+    curl http://cloud-images.ubuntu.com/xenial/current/xenial-server-cloudimg-arm64-uefi1.img | \
+        openstack image create --public --container-format=bare --disk-format=qcow2 --property hw_firmware_type=uefi xenial
+
 ### Configure networking
 
 For the purposes of a quick test, we'll setup an 'external' network and shared router ('provider-router') which will be used by all tenants for public access to instances:


### PR DESCRIPTION
arm64 cloud images must have the "hw_firmware_type" property set to uefi.
There is no legacy BIOS option for ARM. This is also true for armhf images,
but I don't believe those images *just work* in UEFI mode yet, and I don't
want to imply otherwise until they do.