### PR TITLE
Use the official ntp charm instead of an old fork

### DIFF
--- a/development/ceph-base-bionic-luminous/bundle.yaml
+++ b/development/ceph-base-bionic-luminous/bundle.yaml
@@ -43,5 +43,5 @@ services:
     annotations:
       gui-x: '1000'
       gui-y: '0'
-    charm: cs:~openstack-charmers-next/ntp
+    charm: cs:ntp
     num_units: 0

--- a/development/ceph-base-xenial-jewel/bundle.yaml
+++ b/development/ceph-base-xenial-jewel/bundle.yaml
@@ -41,5 +41,5 @@ services:
     annotations:
       gui-x: '1000'
       gui-y: '0'
-    charm: cs:~openstack-charmers-next/ntp
+    charm: cs:ntp
     num_units: 0

--- a/development/ceph-base-xenial-luminous/bundle.yaml
+++ b/development/ceph-base-xenial-luminous/bundle.yaml
@@ -43,5 +43,5 @@ services:
     annotations:
       gui-x: '1000'
       gui-y: '0'
-    charm: cs:~openstack-charmers-next/ntp
+    charm: cs:ntp
     num_units: 0

--- a/development/openstack-base-bionic-queens/bundle.yaml
+++ b/development/openstack-base-bionic-queens/bundle.yaml
@@ -238,7 +238,7 @@ services:
     annotations:
       gui-x: '1000'
       gui-y: '0'
-    charm: cs:~openstack-charmers-next/bionic/ntp
+    charm: cs:ntp
     num_units: 0
   openstack-dashboard:
     annotations:

--- a/development/openstack-base-spaces/bundle.yaml
+++ b/development/openstack-base-spaces/bundle.yaml
@@ -277,7 +277,7 @@ services:
     annotations:
       gui-x: '1000'
       gui-y: '0'
-    charm: cs:~openstack-charmers-next/xenial/ntp
+    charm: cs:ntp
     num_units: 0
   openstack-dashboard:
     annotations:

--- a/development/openstack-base-xenial-mitaka/bundle.yaml
+++ b/development/openstack-base-xenial-mitaka/bundle.yaml
@@ -227,7 +227,7 @@ services:
     annotations:
       gui-x: '1000'
       gui-y: '0'
-    charm: cs:~openstack-charmers-next/xenial/ntp
+    charm: cs:ntp
     num_units: 0
   openstack-dashboard:
     annotations:

--- a/development/openstack-base-xenial-newton/bundle.yaml
+++ b/development/openstack-base-xenial-newton/bundle.yaml
@@ -234,7 +234,7 @@ services:
     annotations:
       gui-x: '1000'
       gui-y: '0'
-    charm: cs:~openstack-charmers-next/xenial/ntp
+    charm: cs:ntp
     num_units: 0
   openstack-dashboard:
     annotations:

--- a/development/openstack-base-xenial-ocata/bundle.yaml
+++ b/development/openstack-base-xenial-ocata/bundle.yaml
@@ -234,7 +234,7 @@ services:
     annotations:
       gui-x: '1000'
       gui-y: '0'
-    charm: cs:~openstack-charmers-next/xenial/ntp
+    charm: cs:ntp
     num_units: 0
   openstack-dashboard:
     annotations:

--- a/development/openstack-base-xenial-pike/bundle.yaml
+++ b/development/openstack-base-xenial-pike/bundle.yaml
@@ -238,7 +238,7 @@ services:
     annotations:
       gui-x: '1000'
       gui-y: '0'
-    charm: cs:~openstack-charmers-next/xenial/ntp
+    charm: cs:ntp
     num_units: 0
   openstack-dashboard:
     annotations:

--- a/development/openstack-base-xenial-queens/bundle.yaml
+++ b/development/openstack-base-xenial-queens/bundle.yaml
@@ -238,7 +238,7 @@ services:
     annotations:
       gui-x: '1000'
       gui-y: '0'
-    charm: cs:~openstack-charmers-next/xenial/ntp
+    charm: cs:ntp
     num_units: 0
   openstack-dashboard:
     annotations:

--- a/development/openstack-lxd-xenial-mitaka/bundle.yaml
+++ b/development/openstack-lxd-xenial-mitaka/bundle.yaml
@@ -208,7 +208,7 @@ services:
     annotations:
       gui-x: '1000'
       gui-y: '0'
-    charm: cs:~openstack-charmers-next/ntp
+    charm: cs:ntp
     num_units: 0
   openstack-dashboard:
     annotations:


### PR DESCRIPTION
Resolve error on more recent series, where the official charm contains series support, and the old tactical fork does not.

ERROR cannot post archive: bundle verification failed: ["application \"ntp\" refers to non-existent charm \"cs:~openstack-charmers-next/bionic/ntp\""]