### PR TITLE
Fix docs

### DIFF
--- a/development/openstack-base-bionic-queens/README.md
+++ b/development/openstack-base-bionic-queens/README.md
@@ -149,8 +149,8 @@ The attached volume will be accessible once you login to the instance (see below
 
 In order to access the instance you just booted on the cloud, you'll need to assign a floating IP address to the instance:
 
-    nova floating-ip-create
-    nova add-floating-ip <uuid-of-instance> <new-floating-ip>
+    openstack floating ip create ext_net
+    openstack server add floating ip xenial-test <new-floating-ip>
 
 and then allow access via SSH (and ping) - you only need todo this once:
 

--- a/development/openstack-base-bionic-queens/README.md
+++ b/development/openstack-base-bionic-queens/README.md
@@ -152,7 +152,7 @@ In order to access the instance you just booted on the cloud, you'll need to ass
     openstack floating ip create ext_net
     openstack server add floating ip xenial-test <new-floating-ip>
 
-and then allow access via SSH (and ping) - you only need todo this once:
+and then allow access via SSH (and ping) - you only need to do these steps:
 
     neutron security-group-rule-create --protocol icmp \
         --direction ingress default

--- a/development/openstack-base-bionic-queens/README.md
+++ b/development/openstack-base-bionic-queens/README.md
@@ -118,6 +118,9 @@ Starting with the OpenStack Newton release, default flavors are no longer create
 
 First generate a SSH keypair so that you can access your instances once you've booted them:
 
+    mkdir -p ~/.ssh
+    touch ~/.ssh/id_rsa_cloud
+    chmod 600 ~/.ssh/id_rsa_cloud
     nova keypair-add mykey > ~/.ssh/id_rsa_cloud
 
 **Note:** you can also upload an existing public key to the cloud rather than generating a new one:

--- a/development/openstack-base-bionic-queens/README.md
+++ b/development/openstack-base-bionic-queens/README.md
@@ -152,13 +152,17 @@ In order to access the instance you just booted on the cloud, you'll need to ass
     openstack floating ip create ext_net
     openstack server add floating ip xenial-test <new-floating-ip>
 
-and then allow access via SSH (and ping) - you only need to do these steps:
+and then allow access via SSH (and ping) - you only need to do these steps once:
+
+    neutron security-group-list
+
+For each security group in the list, identify the UUID and run:
 
     neutron security-group-rule-create --protocol icmp \
-        --direction ingress default
+        --direction ingress <uuid>
     neutron security-group-rule-create --protocol tcp \
         --port-range-min 22 --port-range-max 22 \
-        --direction ingress default
+        --direction ingress <uuid>
 
 After running these commands you should be able to access the instance:
 

--- a/development/openstack-base-spaces/README.md
+++ b/development/openstack-base-spaces/README.md
@@ -154,8 +154,8 @@ The attached volume will be accessible once you login to the instance (see below
 
 In order to access the instance you just booted on the cloud, you'll need to assign a floating IP address to the instance:
 
-    nova floating-ip-create
-    nova add-floating-ip <uuid-of-instance> <new-floating-ip>
+    openstack floating ip create ext_net
+    openstack server add floating ip xenial-test <new-floating-ip>
 
 and then allow access via SSH (and ping) - you only need todo this once:
 

--- a/development/openstack-base-spaces/README.md
+++ b/development/openstack-base-spaces/README.md
@@ -157,13 +157,17 @@ In order to access the instance you just booted on the cloud, you'll need to ass
     openstack floating ip create ext_net
     openstack server add floating ip xenial-test <new-floating-ip>
 
-and then allow access via SSH (and ping) - you only need to do these steps:
+and then allow access via SSH (and ping) - you only need to do these steps once:
+
+    neutron security-group-list
+
+For each security group in the list, identify the UUID and run:
 
     neutron security-group-rule-create --protocol icmp \
-        --direction ingress default
+        --direction ingress <uuid>
     neutron security-group-rule-create --protocol tcp \
         --port-range-min 22 --port-range-max 22 \
-        --direction ingress default
+        --direction ingress <uuid>
 
 After running these commands you should be able to access the instance:
 

--- a/development/openstack-base-spaces/README.md
+++ b/development/openstack-base-spaces/README.md
@@ -123,6 +123,9 @@ Neutron provides a wide range of configuration options; see the [OpenStack Neutr
 
 First generate a SSH keypair so that you can access your instances once you've booted them:
 
+    mkdir -p ~/.ssh
+    touch ~/.ssh/id_rsa_cloud
+    chmod 600 ~/.ssh/id_rsa_cloud
     nova keypair-add mykey > ~/.ssh/id_rsa_cloud
 
 **Note:** you can also upload an existing public key to the cloud rather than generating a new one:

--- a/development/openstack-base-spaces/README.md
+++ b/development/openstack-base-spaces/README.md
@@ -157,7 +157,7 @@ In order to access the instance you just booted on the cloud, you'll need to ass
     openstack floating ip create ext_net
     openstack server add floating ip xenial-test <new-floating-ip>
 
-and then allow access via SSH (and ping) - you only need todo this once:
+and then allow access via SSH (and ping) - you only need to do these steps:
 
     neutron security-group-rule-create --protocol icmp \
         --direction ingress default

--- a/development/openstack-base-xenial-mitaka/README.md
+++ b/development/openstack-base-xenial-mitaka/README.md
@@ -149,8 +149,8 @@ The attached volume will be accessible once you login to the instance (see below
 
 In order to access the instance you just booted on the cloud, you'll need to assign a floating IP address to the instance:
 
-    nova floating-ip-create
-    nova add-floating-ip <uuid-of-instance> <new-floating-ip>
+    openstack floating ip create ext_net
+    openstack server add floating ip xenial-test <new-floating-ip>
 
 and then allow access via SSH (and ping) - you only need todo this once:
 

--- a/development/openstack-base-xenial-mitaka/README.md
+++ b/development/openstack-base-xenial-mitaka/README.md
@@ -152,7 +152,7 @@ In order to access the instance you just booted on the cloud, you'll need to ass
     openstack floating ip create ext_net
     openstack server add floating ip xenial-test <new-floating-ip>
 
-and then allow access via SSH (and ping) - you only need todo this once:
+and then allow access via SSH (and ping) - you only need to do these steps:
 
     neutron security-group-rule-create --protocol icmp \
         --direction ingress default

--- a/development/openstack-base-xenial-mitaka/README.md
+++ b/development/openstack-base-xenial-mitaka/README.md
@@ -118,6 +118,9 @@ Starting with the OpenStack Newton release, default flavors are no longer create
 
 First generate a SSH keypair so that you can access your instances once you've booted them:
 
+    mkdir -p ~/.ssh
+    touch ~/.ssh/id_rsa_cloud
+    chmod 600 ~/.ssh/id_rsa_cloud
     nova keypair-add mykey > ~/.ssh/id_rsa_cloud
 
 **Note:** you can also upload an existing public key to the cloud rather than generating a new one:

--- a/development/openstack-base-xenial-mitaka/README.md
+++ b/development/openstack-base-xenial-mitaka/README.md
@@ -152,13 +152,17 @@ In order to access the instance you just booted on the cloud, you'll need to ass
     openstack floating ip create ext_net
     openstack server add floating ip xenial-test <new-floating-ip>
 
-and then allow access via SSH (and ping) - you only need to do these steps:
+and then allow access via SSH (and ping) - you only need to do these steps once:
+
+    neutron security-group-list
+
+For each security group in the list, identify the UUID and run:
 
     neutron security-group-rule-create --protocol icmp \
-        --direction ingress default
+        --direction ingress <uuid>
     neutron security-group-rule-create --protocol tcp \
         --port-range-min 22 --port-range-max 22 \
-        --direction ingress default
+        --direction ingress <uuid>
 
 After running these commands you should be able to access the instance:
 

--- a/development/openstack-base-xenial-newton/README.md
+++ b/development/openstack-base-xenial-newton/README.md
@@ -149,8 +149,8 @@ The attached volume will be accessible once you login to the instance (see below
 
 In order to access the instance you just booted on the cloud, you'll need to assign a floating IP address to the instance:
 
-    nova floating-ip-create
-    nova add-floating-ip <uuid-of-instance> <new-floating-ip>
+    openstack floating ip create ext_net
+    openstack server add floating ip xenial-test <new-floating-ip>
 
 and then allow access via SSH (and ping) - you only need todo this once:
 

--- a/development/openstack-base-xenial-newton/README.md
+++ b/development/openstack-base-xenial-newton/README.md
@@ -152,7 +152,7 @@ In order to access the instance you just booted on the cloud, you'll need to ass
     openstack floating ip create ext_net
     openstack server add floating ip xenial-test <new-floating-ip>
 
-and then allow access via SSH (and ping) - you only need todo this once:
+and then allow access via SSH (and ping) - you only need to do these steps:
 
     neutron security-group-rule-create --protocol icmp \
         --direction ingress default

--- a/development/openstack-base-xenial-newton/README.md
+++ b/development/openstack-base-xenial-newton/README.md
@@ -118,6 +118,9 @@ Starting with the OpenStack Newton release, default flavors are no longer create
 
 First generate a SSH keypair so that you can access your instances once you've booted them:
 
+    mkdir -p ~/.ssh
+    touch ~/.ssh/id_rsa_cloud
+    chmod 600 ~/.ssh/id_rsa_cloud
     nova keypair-add mykey > ~/.ssh/id_rsa_cloud
 
 **Note:** you can also upload an existing public key to the cloud rather than generating a new one:

--- a/development/openstack-base-xenial-newton/README.md
+++ b/development/openstack-base-xenial-newton/README.md
@@ -152,13 +152,17 @@ In order to access the instance you just booted on the cloud, you'll need to ass
     openstack floating ip create ext_net
     openstack server add floating ip xenial-test <new-floating-ip>
 
-and then allow access via SSH (and ping) - you only need to do these steps:
+and then allow access via SSH (and ping) - you only need to do these steps once:
+
+    neutron security-group-list
+
+For each security group in the list, identify the UUID and run:
 
     neutron security-group-rule-create --protocol icmp \
-        --direction ingress default
+        --direction ingress <uuid>
     neutron security-group-rule-create --protocol tcp \
         --port-range-min 22 --port-range-max 22 \
-        --direction ingress default
+        --direction ingress <uuid>
 
 After running these commands you should be able to access the instance:
 

--- a/development/openstack-base-xenial-ocata/README.md
+++ b/development/openstack-base-xenial-ocata/README.md
@@ -149,8 +149,8 @@ The attached volume will be accessible once you login to the instance (see below
 
 In order to access the instance you just booted on the cloud, you'll need to assign a floating IP address to the instance:
 
-    nova floating-ip-create
-    nova add-floating-ip <uuid-of-instance> <new-floating-ip>
+    openstack floating ip create ext_net
+    openstack server add floating ip xenial-test <new-floating-ip>
 
 and then allow access via SSH (and ping) - you only need todo this once:
 

--- a/development/openstack-base-xenial-ocata/README.md
+++ b/development/openstack-base-xenial-ocata/README.md
@@ -152,7 +152,7 @@ In order to access the instance you just booted on the cloud, you'll need to ass
     openstack floating ip create ext_net
     openstack server add floating ip xenial-test <new-floating-ip>
 
-and then allow access via SSH (and ping) - you only need todo this once:
+and then allow access via SSH (and ping) - you only need to do these steps:
 
     neutron security-group-rule-create --protocol icmp \
         --direction ingress default

--- a/development/openstack-base-xenial-ocata/README.md
+++ b/development/openstack-base-xenial-ocata/README.md
@@ -118,6 +118,9 @@ Starting with the OpenStack Newton release, default flavors are no longer create
 
 First generate a SSH keypair so that you can access your instances once you've booted them:
 
+    mkdir -p ~/.ssh
+    touch ~/.ssh/id_rsa_cloud
+    chmod 600 ~/.ssh/id_rsa_cloud
     nova keypair-add mykey > ~/.ssh/id_rsa_cloud
 
 **Note:** you can also upload an existing public key to the cloud rather than generating a new one:

--- a/development/openstack-base-xenial-ocata/README.md
+++ b/development/openstack-base-xenial-ocata/README.md
@@ -152,13 +152,17 @@ In order to access the instance you just booted on the cloud, you'll need to ass
     openstack floating ip create ext_net
     openstack server add floating ip xenial-test <new-floating-ip>
 
-and then allow access via SSH (and ping) - you only need to do these steps:
+and then allow access via SSH (and ping) - you only need to do these steps once:
+
+    neutron security-group-list
+
+For each security group in the list, identify the UUID and run:
 
     neutron security-group-rule-create --protocol icmp \
-        --direction ingress default
+        --direction ingress <uuid>
     neutron security-group-rule-create --protocol tcp \
         --port-range-min 22 --port-range-max 22 \
-        --direction ingress default
+        --direction ingress <uuid>
 
 After running these commands you should be able to access the instance:
 

--- a/development/openstack-base-xenial-pike/README.md
+++ b/development/openstack-base-xenial-pike/README.md
@@ -149,8 +149,8 @@ The attached volume will be accessible once you login to the instance (see below
 
 In order to access the instance you just booted on the cloud, you'll need to assign a floating IP address to the instance:
 
-    nova floating-ip-create
-    nova add-floating-ip <uuid-of-instance> <new-floating-ip>
+    openstack floating ip create ext_net
+    openstack server add floating ip xenial-test <new-floating-ip>
 
 and then allow access via SSH (and ping) - you only need todo this once:
 

--- a/development/openstack-base-xenial-pike/README.md
+++ b/development/openstack-base-xenial-pike/README.md
@@ -152,7 +152,7 @@ In order to access the instance you just booted on the cloud, you'll need to ass
     openstack floating ip create ext_net
     openstack server add floating ip xenial-test <new-floating-ip>
 
-and then allow access via SSH (and ping) - you only need todo this once:
+and then allow access via SSH (and ping) - you only need to do these steps:
 
     neutron security-group-rule-create --protocol icmp \
         --direction ingress default

--- a/development/openstack-base-xenial-pike/README.md
+++ b/development/openstack-base-xenial-pike/README.md
@@ -118,6 +118,9 @@ Starting with the OpenStack Newton release, default flavors are no longer create
 
 First generate a SSH keypair so that you can access your instances once you've booted them:
 
+    mkdir -p ~/.ssh
+    touch ~/.ssh/id_rsa_cloud
+    chmod 600 ~/.ssh/id_rsa_cloud
     nova keypair-add mykey > ~/.ssh/id_rsa_cloud
 
 **Note:** you can also upload an existing public key to the cloud rather than generating a new one:

--- a/development/openstack-base-xenial-pike/README.md
+++ b/development/openstack-base-xenial-pike/README.md
@@ -152,13 +152,17 @@ In order to access the instance you just booted on the cloud, you'll need to ass
     openstack floating ip create ext_net
     openstack server add floating ip xenial-test <new-floating-ip>
 
-and then allow access via SSH (and ping) - you only need to do these steps:
+and then allow access via SSH (and ping) - you only need to do these steps once:
+
+    neutron security-group-list
+
+For each security group in the list, identify the UUID and run:
 
     neutron security-group-rule-create --protocol icmp \
-        --direction ingress default
+        --direction ingress <uuid>
     neutron security-group-rule-create --protocol tcp \
         --port-range-min 22 --port-range-max 22 \
-        --direction ingress default
+        --direction ingress <uuid>
 
 After running these commands you should be able to access the instance:
 

--- a/development/openstack-base-xenial-queens/README.md
+++ b/development/openstack-base-xenial-queens/README.md
@@ -149,8 +149,8 @@ The attached volume will be accessible once you login to the instance (see below
 
 In order to access the instance you just booted on the cloud, you'll need to assign a floating IP address to the instance:
 
-    nova floating-ip-create
-    nova add-floating-ip <uuid-of-instance> <new-floating-ip>
+    openstack floating ip create ext_net
+    openstack server add floating ip xenial-test <new-floating-ip>
 
 and then allow access via SSH (and ping) - you only need todo this once:
 

--- a/development/openstack-base-xenial-queens/README.md
+++ b/development/openstack-base-xenial-queens/README.md
@@ -152,7 +152,7 @@ In order to access the instance you just booted on the cloud, you'll need to ass
     openstack floating ip create ext_net
     openstack server add floating ip xenial-test <new-floating-ip>
 
-and then allow access via SSH (and ping) - you only need todo this once:
+and then allow access via SSH (and ping) - you only need to do these steps:
 
     neutron security-group-rule-create --protocol icmp \
         --direction ingress default

--- a/development/openstack-base-xenial-queens/README.md
+++ b/development/openstack-base-xenial-queens/README.md
@@ -118,6 +118,9 @@ Starting with the OpenStack Newton release, default flavors are no longer create
 
 First generate a SSH keypair so that you can access your instances once you've booted them:
 
+    mkdir -p ~/.ssh
+    touch ~/.ssh/id_rsa_cloud
+    chmod 600 ~/.ssh/id_rsa_cloud
     nova keypair-add mykey > ~/.ssh/id_rsa_cloud
 
 **Note:** you can also upload an existing public key to the cloud rather than generating a new one:

--- a/development/openstack-base-xenial-queens/README.md
+++ b/development/openstack-base-xenial-queens/README.md
@@ -152,13 +152,17 @@ In order to access the instance you just booted on the cloud, you'll need to ass
     openstack floating ip create ext_net
     openstack server add floating ip xenial-test <new-floating-ip>
 
-and then allow access via SSH (and ping) - you only need to do these steps:
+and then allow access via SSH (and ping) - you only need to do these steps once:
+
+    neutron security-group-list
+
+For each security group in the list, identify the UUID and run:
 
     neutron security-group-rule-create --protocol icmp \
-        --direction ingress default
+        --direction ingress <uuid>
     neutron security-group-rule-create --protocol tcp \
         --port-range-min 22 --port-range-max 22 \
-        --direction ingress default
+        --direction ingress <uuid>
 
 After running these commands you should be able to access the instance:
 

--- a/development/openstack-lxd-xenial-mitaka/README.md
+++ b/development/openstack-lxd-xenial-mitaka/README.md
@@ -127,7 +127,7 @@ In order to access the instance you just booted on the cloud, you'll need to ass
     openstack floating ip create ext_net
     openstack server add floating ip xenial-test <new-floating-ip>
 
-and then allow access via SSH (and ping) - you only need todo this once:
+and then allow access via SSH (and ping) - you only need to do these steps:
 
     neutron security-group-rule-create --protocol icmp \
         --direction ingress default

--- a/development/openstack-lxd-xenial-mitaka/README.md
+++ b/development/openstack-lxd-xenial-mitaka/README.md
@@ -127,13 +127,17 @@ In order to access the instance you just booted on the cloud, you'll need to ass
     openstack floating ip create ext_net
     openstack server add floating ip xenial-test <new-floating-ip>
 
-and then allow access via SSH (and ping) - you only need to do these steps:
+and then allow access via SSH (and ping) - you only need to do these steps once:
+
+    neutron security-group-list
+
+For each security group in the list, identify the UUID and run:
 
     neutron security-group-rule-create --protocol icmp \
-        --direction ingress default
+        --direction ingress <uuid>
     neutron security-group-rule-create --protocol tcp \
         --port-range-min 22 --port-range-max 22 \
-        --direction ingress default
+        --direction ingress <uuid>
 
 After running these commands you should be able to access the instance:
 

--- a/development/openstack-lxd-xenial-mitaka/README.md
+++ b/development/openstack-lxd-xenial-mitaka/README.md
@@ -124,8 +124,8 @@ You can now boot an instance on your cloud:
 
 In order to access the instance you just booted on the cloud, you'll need to assign a floating IP address to the instance:
 
-    nova floating-ip-create
-    nova add-floating-ip <uuid-of-instance> <new-floating-ip>
+    openstack floating ip create ext_net
+    openstack server add floating ip xenial-test <new-floating-ip>
 
 and then allow access via SSH (and ping) - you only need todo this once:
 

--- a/development/openstack-lxd-xenial-mitaka/README.md
+++ b/development/openstack-lxd-xenial-mitaka/README.md
@@ -105,6 +105,9 @@ Neutron provides a wide range of configuration options; see the [OpenStack Neutr
 
 First generate a SSH keypair so that you can access your instances once you've booted them:
 
+    mkdir -p ~/.ssh
+    touch ~/.ssh/id_rsa_cloud
+    chmod 600 ~/.ssh/id_rsa_cloud
     nova keypair-add mykey > ~/.ssh/id_rsa_cloud
 
 **Note:** you can also upload an existing public key to the cloud rather than generating a new one:

--- a/stable/openstack-base/README.md
+++ b/stable/openstack-base/README.md
@@ -150,13 +150,17 @@ In order to access the instance you just booted on the cloud, you'll need to ass
     openstack floating ip create ext_net
     openstack server add floating ip xenial-test <new-floating-ip>
 
-and then allow access via SSH (and ping) - you only need to do these steps:
+and then allow access via SSH (and ping) - you only need to do these steps once:
+
+    neutron security-group-list
+
+For each security group in the list, identify the UUID and run:
 
     neutron security-group-rule-create --protocol icmp \
-        --direction ingress default
+        --direction ingress <uuid>
     neutron security-group-rule-create --protocol tcp \
         --port-range-min 22 --port-range-max 22 \
-        --direction ingress default
+        --direction ingress <uuid>
 
 After running these commands you should be able to access the instance:
 

--- a/stable/openstack-base/README.md
+++ b/stable/openstack-base/README.md
@@ -116,6 +116,9 @@ Starting with the OpenStack Newton release, default flavors are no longer create
 
 First generate a SSH keypair so that you can access your instances once you've booted them:
 
+    mkdir -p ~/.ssh
+    touch ~/.ssh/id_rsa_cloud
+    chmod 600 ~/.ssh/id_rsa_cloud
     nova keypair-add mykey > ~/.ssh/id_rsa_cloud
 
 **Note:** you can also upload an existing public key to the cloud rather than generating a new one:

--- a/stable/openstack-base/README.md
+++ b/stable/openstack-base/README.md
@@ -147,8 +147,8 @@ The attached volume will be accessible once you login to the instance (see below
 
 In order to access the instance you just booted on the cloud, you'll need to assign a floating IP address to the instance:
 
-    nova floating-ip-create
-    nova add-floating-ip <uuid-of-instance> <new-floating-ip>
+    openstack floating ip create ext_net
+    openstack server add floating ip xenial-test <new-floating-ip>
 
 and then allow access via SSH (and ping) - you only need todo this once:
 

--- a/stable/openstack-base/README.md
+++ b/stable/openstack-base/README.md
@@ -150,7 +150,7 @@ In order to access the instance you just booted on the cloud, you'll need to ass
     openstack floating ip create ext_net
     openstack server add floating ip xenial-test <new-floating-ip>
 
-and then allow access via SSH (and ping) - you only need todo this once:
+and then allow access via SSH (and ping) - you only need to do these steps:
 
     neutron security-group-rule-create --protocol icmp \
         --direction ingress default

--- a/stable/openstack-lxd/README.md
+++ b/stable/openstack-lxd/README.md
@@ -111,6 +111,9 @@ Starting with the OpenStack Newton release, default flavors are no longer create
 
 First generate a SSH keypair so that you can access your instances once you've booted them:
 
+    mkdir -p ~/.ssh
+    touch ~/.ssh/id_rsa_cloud
+    chmod 600 ~/.ssh/id_rsa_cloud
     nova keypair-add mykey > ~/.ssh/id_rsa_cloud
 
 **Note:** you can also upload an existing public key to the cloud rather than generating a new one:

--- a/stable/openstack-lxd/README.md
+++ b/stable/openstack-lxd/README.md
@@ -133,13 +133,17 @@ In order to access the instance you just booted on the cloud, you'll need to ass
     openstack floating ip create ext_net
     openstack server add floating ip xenial-test <new-floating-ip>
 
-and then allow access via SSH (and ping) - you only need to do these steps:
+and then allow access via SSH (and ping) - you only need to do these steps once:
+
+    neutron security-group-list
+
+For each security group in the list, identify the UUID and run:
 
     neutron security-group-rule-create --protocol icmp \
-        --direction ingress default
+        --direction ingress <uuid>
     neutron security-group-rule-create --protocol tcp \
         --port-range-min 22 --port-range-max 22 \
-        --direction ingress default
+        --direction ingress <uuid>
 
 After running these commands you should be able to access the instance:
 

--- a/stable/openstack-lxd/README.md
+++ b/stable/openstack-lxd/README.md
@@ -133,7 +133,7 @@ In order to access the instance you just booted on the cloud, you'll need to ass
     openstack floating ip create ext_net
     openstack server add floating ip xenial-test <new-floating-ip>
 
-and then allow access via SSH (and ping) - you only need todo this once:
+and then allow access via SSH (and ping) - you only need to do these steps:
 
     neutron security-group-rule-create --protocol icmp \
         --direction ingress default

--- a/stable/openstack-lxd/README.md
+++ b/stable/openstack-lxd/README.md
@@ -130,8 +130,8 @@ You can now boot an instance on your cloud:
 
 In order to access the instance you just booted on the cloud, you'll need to assign a floating IP address to the instance:
 
-    nova floating-ip-create
-    nova add-floating-ip <uuid-of-instance> <new-floating-ip>
+    openstack floating ip create ext_net
+    openstack server add floating ip xenial-test <new-floating-ip>
 
 and then allow access via SSH (and ping) - you only need todo this once:
 


### PR DESCRIPTION
I ran into several issues while trying to walkthrough the "Ensure it's working" section of the documentation.
This updates the document to use commands that worked for me. There maybe better commands that are more future-proof (some of them emit deprecation warnings), but at least these work. Tested on a xenial-pike install.

LP: #1736795.