### PR TITLE
Updated ghnocchi charm to include cloud-archive in stable-telemetry

### DIFF
--- a/stable/openstack-telemetry/bundle.yaml
+++ b/stable/openstack-telemetry/bundle.yaml
@@ -208,6 +208,8 @@ services:
   gnocchi:
     charm: cs:gnocchi-7
     num_units: 1
+    options:
+      openstack-origin: cloud:xenial-queens
     to:
     - lxd:1
   keystone:


### PR DESCRIPTION
Updated stable/telemetry bundle
   -- gnocchi charm to include cloud-archive, tested on bare metal. 