### PR TITLE
Add overlays for encryption at rest

### DIFF
--- a/development/overlays/encryption-at-rest.yaml
+++ b/development/overlays/encryption-at-rest.yaml
@@ -1,0 +1,37 @@
+# Encryption at rest - requires Pike or later
+# for Ceph Luminous support
+---
+applications:
+  ceph-osd:
+    options:
+      osd-encrypt: true
+      osd-encrypt-keymanager: vault
+  easyrsa:
+    charm: "cs:~containers/easyrsa"
+    num_units: 1
+    to: lxd:0
+  etcd:
+    charm: "cs:etcd"
+    num_units: 1
+    options:
+      channel: 3.1/stable
+    to: lxd:1
+  vault:
+    charm: "cs:~openstack-charmers-next/vault"
+    num_units: 1
+    to: lxd:2
+  nova-compute:
+    options:
+      encrypt: true
+      ephemeral-storage: /dev/sdc
+relations:
+  - - ceph-osd:secrets-storage
+    - vault:secrets
+  - - vault:shared-db
+    - mysql:shared-db
+  - - etcd:certificates
+    - easyrsa:client
+  - - etcd:db
+    - vault:etcd
+  - - vault:secrets
+    - nova-compute:secrets-storage

--- a/stable/overlays/encryption-at-rest.yaml
+++ b/stable/overlays/encryption-at-rest.yaml
@@ -1,0 +1,37 @@
+# Encryption at rest - requires Pike or later
+# for Ceph Luminous support
+---
+applications:
+  ceph-osd:
+    options:
+      osd-encrypt: true
+      osd-encrypt-keymanager: vault
+  easyrsa:
+    charm: "cs:~containers/easyrsa"
+    num_units: 1
+    to: lxd:0
+  etcd:
+    charm: "cs:etcd"
+    num_units: 1
+    options:
+      channel: 3.1/stable
+    to: lxd:1
+  vault:
+    charm: "cs:vault"
+    num_units: 1
+    to: lxd:2
+  nova-compute:
+    options:
+      encrypt: true
+      ephemeral-device: /dev/sdc
+relations:
+  - - ceph-osd:secrets-storage
+    - vault:secrets
+  - - vault:shared-db
+    - mysql:shared-db
+  - - etcd:certificates
+    - easyrsa:client
+  - - etcd:db
+    - vault:etcd
+  - - vault:secrets
+    - nova-compute:secrets-storage


### PR DESCRIPTION
Add devel and stable overlays for upcoming encryption at rest
feature using vault.

This include coverage for ceph-osd and nova-compute; swift is
no included in the openstack-base bundle so is skipped for now.