### PR TITLE
Remove `osd-reformat` and `overwrite` options from bundles

### DIFF
--- a/development/ceph-base-bionic-luminous/bundle.yaml
+++ b/development/ceph-base-bionic-luminous/bundle.yaml
@@ -33,7 +33,6 @@ services:
     num_units: 3
     options:
       osd-devices: /dev/sdb
-      osd-reformat: True
       source: proposed
     to:
     - '0'

--- a/development/ceph-base-xenial-jewel/bundle.yaml
+++ b/development/ceph-base-xenial-jewel/bundle.yaml
@@ -32,7 +32,6 @@ services:
     num_units: 3
     options:
       osd-devices: /dev/sdb
-      osd-reformat: True
     to:
     - '0'
     - '1'

--- a/development/ceph-base-xenial-luminous/bundle.yaml
+++ b/development/ceph-base-xenial-luminous/bundle.yaml
@@ -33,7 +33,6 @@ services:
     num_units: 3
     options:
       osd-devices: /dev/sdb
-      osd-reformat: True
       source: cloud:xenial-pike
     to:
     - '0'

--- a/development/openstack-base-bionic-queens/bundle.yaml
+++ b/development/openstack-base-bionic-queens/bundle.yaml
@@ -104,7 +104,6 @@ services:
     num_units: 3
     options:
       osd-devices: /dev/sdb
-      osd-reformat: True
     to:
     - '1'
     - '2'

--- a/development/openstack-base-spaces/bundle.yaml
+++ b/development/openstack-base-spaces/bundle.yaml
@@ -110,7 +110,6 @@ services:
     num_units: 3
     options:
       osd-devices: /dev/sdb
-      osd-reformat: True
     bindings:
       public: public
       cluster: internal

--- a/development/openstack-base-xenial-mitaka/bundle.yaml
+++ b/development/openstack-base-xenial-mitaka/bundle.yaml
@@ -104,7 +104,6 @@ services:
     num_units: 3
     options:
       osd-devices: /dev/sdb
-      osd-reformat: True
     to:
     - '1'
     - '2'

--- a/development/openstack-base-xenial-newton/bundle.yaml
+++ b/development/openstack-base-xenial-newton/bundle.yaml
@@ -104,7 +104,6 @@ services:
     num_units: 3
     options:
       osd-devices: /dev/sdb
-      osd-reformat: True
     to:
     - '1'
     - '2'

--- a/development/openstack-base-xenial-ocata/bundle.yaml
+++ b/development/openstack-base-xenial-ocata/bundle.yaml
@@ -104,7 +104,6 @@ services:
     num_units: 3
     options:
       osd-devices: /dev/sdb
-      osd-reformat: True
     to:
     - '1'
     - '2'

--- a/development/openstack-base-xenial-pike/bundle.yaml
+++ b/development/openstack-base-xenial-pike/bundle.yaml
@@ -105,7 +105,6 @@ services:
     num_units: 3
     options:
       osd-devices: /dev/sdb
-      osd-reformat: True
       source: cloud:xenial-pike
     to:
     - '1'

--- a/development/openstack-base-xenial-queens/bundle.yaml
+++ b/development/openstack-base-xenial-queens/bundle.yaml
@@ -105,7 +105,6 @@ services:
     num_units: 3
     options:
       osd-devices: /dev/sdb
-      osd-reformat: True
       source: cloud:xenial-queens/proposed
     to:
     - '1'

--- a/development/openstack-dpdk/bundle.yaml
+++ b/development/openstack-dpdk/bundle.yaml
@@ -89,7 +89,6 @@ services:
       fsid: 5a791d94-980b-11e4-b6f6-3c970e8b1cf7
       monitor-secret: AQAi5a9UeJXUExAA+By9u+GPhl8/XiUQ4nwI3A==
       osd-devices: /dev/sdb
-      osd-reformat: True
     to:
     - '0'
     - '1'
@@ -101,7 +100,6 @@ services:
     charm: cs:~openstack-charmers-next/xenial/ceph-osd
     options:
       osd-devices: /dev/sdb
-      osd-reformat: True
   ceph-radosgw:
     annotations:
       gui-x: '1000'

--- a/development/openstack-lxd-bionic-queens/bundle.yaml
+++ b/development/openstack-lxd-bionic-queens/bundle.yaml
@@ -92,7 +92,6 @@ services:
     num_units: 3
     options:
       osd-devices: /srv/ceph-osd
-      osd-reformat: True
       #source: cloud:bionic-queens
     to:
     - '1'
@@ -137,7 +136,6 @@ services:
     num_units: 0
     options:
       block-devices: /dev/sdb
-      overwrite: true
       storage-type: zfs
   mysql:
     annotations:

--- a/development/openstack-lxd-xenial-mitaka/bundle.yaml
+++ b/development/openstack-lxd-xenial-mitaka/bundle.yaml
@@ -90,7 +90,6 @@ services:
     num_units: 3
     options:
       osd-devices: /srv/ceph-osd
-      osd-reformat: True
     to:
     - '1'
     - '2'
@@ -129,7 +128,6 @@ services:
     num_units: 0
     options:
       block-devices: /dev/sdb
-      overwrite: true
       storage-type: zfs
   mysql:
     annotations:

--- a/development/openstack-lxd-xenial-queens/bundle.yaml
+++ b/development/openstack-lxd-xenial-queens/bundle.yaml
@@ -92,7 +92,6 @@ services:
     num_units: 3
     options:
       osd-devices: /srv/ceph-osd
-      osd-reformat: True
       source: cloud:xenial-queens/proposed
     to:
     - '1'
@@ -137,7 +136,6 @@ services:
     num_units: 0
     options:
       block-devices: /dev/sdb
-      overwrite: true
       storage-type: zfs
   mysql:
     annotations:

--- a/development/openstack-refstack-xenial-ocata-ppc64el-alt/bundle.yaml
+++ b/development/openstack-refstack-xenial-ocata-ppc64el-alt/bundle.yaml
@@ -152,7 +152,6 @@ services:
     num_units: 3
     options:
       osd-devices: /dev/sdb
-      osd-reformat: True
     to:
     - '0'
     - '1'

--- a/development/openstack-refstack-xenial-ocata/bundle.yaml
+++ b/development/openstack-refstack-xenial-ocata/bundle.yaml
@@ -148,7 +148,6 @@ services:
     num_units: 3
     options:
       osd-devices: /dev/sdb
-      osd-reformat: True
     to:
     - '0'
     - '1'

--- a/development/openstack-refstack-xenial-pike-ppc64el-alt/bundle.yaml
+++ b/development/openstack-refstack-xenial-pike-ppc64el-alt/bundle.yaml
@@ -153,7 +153,6 @@ services:
     num_units: 3
     options:
       osd-devices: /dev/sdb
-      osd-reformat: True
       source: cloud:xenial-pike
     to:
     - '0'

--- a/development/openstack-refstack-xenial-pike/bundle.yaml
+++ b/development/openstack-refstack-xenial-pike/bundle.yaml
@@ -149,7 +149,6 @@ services:
     num_units: 3
     options:
       osd-devices: /dev/sdb
-      osd-reformat: True
       source: cloud:xenial-pike
     to:
     - '0'

--- a/development/openstack-telemetry-bionic-queens/bundle.yaml
+++ b/development/openstack-telemetry-bionic-queens/bundle.yaml
@@ -154,7 +154,6 @@ services:
     num_units: 3
     options:
       osd-devices: /dev/sdb
-      osd-reformat: True
     to:
     - '1'
     - '2'

--- a/development/openstack-telemetry-xenial-mitaka/bundle.yaml
+++ b/development/openstack-telemetry-xenial-mitaka/bundle.yaml
@@ -144,7 +144,6 @@ services:
     num_units: 3
     options:
       osd-devices: /dev/sdb
-      osd-reformat: True
     to:
     - '1'
     - '2'

--- a/development/openstack-telemetry-xenial-newton/bundle.yaml
+++ b/development/openstack-telemetry-xenial-newton/bundle.yaml
@@ -149,7 +149,6 @@ services:
     num_units: 3
     options:
       osd-devices: /dev/sdb
-      osd-reformat: True
       source: cloud:xenial-newton
     to:
     - '1'

--- a/development/openstack-telemetry-xenial-ocata/bundle.yaml
+++ b/development/openstack-telemetry-xenial-ocata/bundle.yaml
@@ -149,7 +149,6 @@ services:
     num_units: 3
     options:
       osd-devices: /dev/sdb
-      osd-reformat: True
       source: cloud:xenial-ocata
     to:
     - '1'

--- a/development/openstack-telemetry-xenial-pike/bundle.yaml
+++ b/development/openstack-telemetry-xenial-pike/bundle.yaml
@@ -149,7 +149,6 @@ services:
     num_units: 3
     options:
       osd-devices: /dev/sdb
-      osd-reformat: True
       source: cloud:xenial-pike
     to:
     - '1'

--- a/development/openstack-telemetry-xenial-queens/bundle.yaml
+++ b/development/openstack-telemetry-xenial-queens/bundle.yaml
@@ -159,7 +159,6 @@ services:
     num_units: 3
     options:
       osd-devices: /dev/sdb
-      osd-reformat: True
       source: cloud:xenial-queens/proposed
     to:
     - '1'

--- a/stable/ceph-base/bundle.yaml
+++ b/stable/ceph-base/bundle.yaml
@@ -33,7 +33,6 @@ services:
     num_units: 3
     options:
       osd-devices: /dev/sdb
-      osd-reformat: 'yes'
       source: cloud:xenial-pike
     to:
     - '0'

--- a/stable/openstack-base/bundle.yaml
+++ b/stable/openstack-base/bundle.yaml
@@ -105,7 +105,6 @@ services:
     num_units: 3
     options:
       osd-devices: /dev/sdb
-      osd-reformat: 'yes'
       source: cloud:xenial-queens
     to:
     - '1'

--- a/stable/openstack-lxd/bundle.yaml
+++ b/stable/openstack-lxd/bundle.yaml
@@ -92,7 +92,6 @@ services:
     num_units: 3
     options:
       osd-devices: /srv/ceph-osd
-      osd-reformat: 'yes'
       #source: cloud:bionic-queens
     to:
     - '1'
@@ -137,7 +136,6 @@ services:
     num_units: 0
     options:
       block-devices: /dev/sdb
-      overwrite: true
       storage-type: zfs
   mysql:
     annotations:

--- a/stable/openstack-telemetry/bundle.yaml
+++ b/stable/openstack-telemetry/bundle.yaml
@@ -159,7 +159,6 @@ services:
     num_units: 3
     options:
       osd-devices: /dev/sdb
-      osd-reformat: 'yes'
       source: cloud:xenial-queens
     to:
     - '1'


### PR DESCRIPTION
While these configuration options may give a smooth deploy
and test experience, they do not come without peril when
used in the wrong situation or left on in deployment that
matures into production.