### PR TITLE
Add bugs-url and homepage links when publishing bundles

### DIFF
--- a/development/push-and-publish.sh
+++ b/development/push-and-publish.sh
@@ -28,6 +28,11 @@ if [ -z "$bundle_id" ]; then
     exit 1
 fi
 
+echo "Setting bugs-url and homepage"
+charm set $bundle_id \
+    bugs-url=https://bugs.launchpad.net/openstack-bundles/+filebug \
+    homepage=https://github.com/openstack-charmers/openstack-bundles/
+
 echo "Publishing new bundle version to stable"
 charm release $bundle_id
 echo "Ensuring global read permissions"

--- a/stable/push-and-publish.sh
+++ b/stable/push-and-publish.sh
@@ -28,6 +28,11 @@ if [ -z "$bundle_id" ]; then
     exit 1
 fi
 
+echo "Setting bugs-url and homepage"
+charm set $bundle_id \
+    bugs-url=https://bugs.launchpad.net/openstack-bundles/+filebug \
+    homepage=https://github.com/openstack-charmers/openstack-bundles/
+
 echo "Publishing new bundle version to stable"
 charm release $bundle_id
 echo "Ensuring global read permissions"


### PR DESCRIPTION
Both for stable and development bundles.

Although the development bundles are in the `openstack-charmers-next`
namespace and not promulgated to the first page, we do have community
users taking them for a spin.  They should know where to find us.