### PR TITLE
Remove proposed as source/origin for development bundles

### DIFF
--- a/development/ceph-base-bionic-luminous/bundle.yaml
+++ b/development/ceph-base-bionic-luminous/bundle.yaml
@@ -20,7 +20,6 @@ services:
     num_units: 3
     options:
       expected-osd-count: 3
-      source: proposed
     to:
     - 'lxd:0'
     - 'lxd:1'
@@ -33,7 +32,6 @@ services:
     num_units: 3
     options:
       osd-devices: /dev/sdb
-      source: proposed
     to:
     - '0'
     - '1'

--- a/development/openstack-base-xenial-queens/bundle.yaml
+++ b/development/openstack-base-xenial-queens/bundle.yaml
@@ -92,7 +92,7 @@ services:
     num_units: 3
     options:
       expected-osd-count: 3
-      source: cloud:xenial-queens/proposed
+      source: cloud:xenial-queens
     to:
     - 'lxd:1'
     - 'lxd:2'
@@ -105,7 +105,7 @@ services:
     num_units: 3
     options:
       osd-devices: /dev/sdb
-      source: cloud:xenial-queens/proposed
+      source: cloud:xenial-queens
     to:
     - '1'
     - '2'
@@ -117,7 +117,7 @@ services:
     charm: cs:~openstack-charmers-next/xenial/ceph-radosgw
     num_units: 1
     options:
-      source: cloud:xenial-queens/proposed
+      source: cloud:xenial-queens
     to:
     - lxd:0
   cinder:
@@ -127,7 +127,7 @@ services:
     charm: cs:~openstack-charmers-next/xenial/cinder
     num_units: 1
     options:
-      openstack-origin: cloud:xenial-queens/proposed
+      openstack-origin: cloud:xenial-queens
       block-device: None
       glance-api-version: 2
       worker-multiplier: 0.25
@@ -146,7 +146,7 @@ services:
     charm: cs:~openstack-charmers-next/xenial/glance
     num_units: 1
     options:
-      openstack-origin: cloud:xenial-queens/proposed
+      openstack-origin: cloud:xenial-queens
       worker-multiplier: 0.25
     to:
     - lxd:2
@@ -157,7 +157,7 @@ services:
     charm: cs:~openstack-charmers-next/xenial/keystone
     num_units: 1
     options:
-      openstack-origin: cloud:xenial-queens/proposed
+      openstack-origin: cloud:xenial-queens
       worker-multiplier: 0.25
     to:
     - lxd:3
@@ -179,7 +179,7 @@ services:
     charm: cs:~openstack-charmers-next/xenial/neutron-api
     num_units: 1
     options:
-      openstack-origin: cloud:xenial-queens/proposed
+      openstack-origin: cloud:xenial-queens
       neutron-security-groups: true
       flat-network-providers: physnet1
       worker-multiplier: 0.25
@@ -192,7 +192,7 @@ services:
     charm: cs:~openstack-charmers-next/xenial/neutron-gateway
     num_units: 1
     options:
-      openstack-origin: cloud:xenial-queens/proposed
+      openstack-origin: cloud:xenial-queens
       bridge-mappings: physnet1:br-ex
       data-port: br-ex:eno2
       worker-multiplier: 0.25
@@ -211,7 +211,7 @@ services:
     charm: cs:~openstack-charmers-next/xenial/nova-cloud-controller
     num_units: 1
     options:
-      openstack-origin: cloud:xenial-queens/proposed
+      openstack-origin: cloud:xenial-queens
       network-manager: Neutron
       worker-multiplier: 0.25
     to:
@@ -224,7 +224,7 @@ services:
     num_units: 3
     options:
       config-flags: default_ephemeral_format=ext4
-      openstack-origin: cloud:xenial-queens/proposed
+      openstack-origin: cloud:xenial-queens
       enable-live-migration: true
       enable-resize: true
       migration-auth-type: ssh
@@ -245,7 +245,7 @@ services:
     charm: cs:~openstack-charmers-next/xenial/openstack-dashboard
     num_units: 1
     options:
-      openstack-origin: cloud:xenial-queens/proposed
+      openstack-origin: cloud:xenial-queens
     to:
     - lxd:3
   rabbitmq-server:
@@ -255,6 +255,6 @@ services:
     charm: cs:~openstack-charmers-next/xenial/rabbitmq-server
     num_units: 1
     options:
-      source: cloud:xenial-queens/proposed
+      source: cloud:xenial-queens
     to:
     - lxd:0

--- a/development/openstack-lxd-xenial-queens/bundle.yaml
+++ b/development/openstack-lxd-xenial-queens/bundle.yaml
@@ -79,7 +79,7 @@ services:
     options:
       default-rbd-features: 1
       expected-osd-count: 3
-      source: cloud:xenial-queens/proposed
+      source: cloud:xenial-queens
     to:
     - lxd:1
     - lxd:2
@@ -92,7 +92,7 @@ services:
     num_units: 3
     options:
       osd-devices: /srv/ceph-osd
-      source: cloud:xenial-queens/proposed
+      source: cloud:xenial-queens
     to:
     - '1'
     - '2'
@@ -106,7 +106,7 @@ services:
     to:
     - lxd:0
     options:
-      source: cloud:xenial-queens/proposed
+      source: cloud:xenial-queens
   glance:
     annotations:
       gui-x: '250'
@@ -116,7 +116,7 @@ services:
     to:
     - lxd:2
     options:
-      openstack-origin: cloud:xenial-queens/proposed
+      openstack-origin: cloud:xenial-queens
   keystone:
     annotations:
       gui-x: '500'
@@ -124,7 +124,7 @@ services:
     charm: cs:~openstack-charmers-next/keystone
     num_units: 1
     options:
-      openstack-origin: cloud:xenial-queens/proposed
+      openstack-origin: cloud:xenial-queens
     to:
     - lxd:3
   lxd:
@@ -157,7 +157,7 @@ services:
       flat-network-providers: physnet1
       neutron-security-groups: true
       worker-multiplier: 0.25
-      openstack-origin: cloud:xenial-queens/proposed
+      openstack-origin: cloud:xenial-queens
     to:
     - lxd:1
   neutron-gateway:
@@ -169,7 +169,7 @@ services:
     options:
       bridge-mappings: physnet1:br-ex
       data-port: br-ex:eno2
-      openstack-origin: cloud:xenial-queens/proposed
+      openstack-origin: cloud:xenial-queens
       worker-multiplier: 0.25
       instance-mtu: 1456
     to:
@@ -188,7 +188,7 @@ services:
     num_units: 1
     options:
       network-manager: Neutron
-      openstack-origin: cloud:xenial-queens/proposed
+      openstack-origin: cloud:xenial-queens
       worker-multiplier: 0.25
     to:
     - lxd:2
@@ -204,7 +204,7 @@ services:
       enable-resize: true
       migration-auth-type: ssh
       virt-type: lxd
-      openstack-origin: cloud:xenial-queens/proposed
+      openstack-origin: cloud:xenial-queens
     to:
     - '1'
     - '2'
@@ -222,7 +222,7 @@ services:
     charm: cs:~openstack-charmers-next/openstack-dashboard
     num_units: 1
     options:
-      openstack-origin: cloud:xenial-queens/proposed
+      openstack-origin: cloud:xenial-queens
     to:
     - lxd:3
   rabbitmq-server:
@@ -232,6 +232,6 @@ services:
     charm: cs:~openstack-charmers-next/rabbitmq-server
     num_units: 1
     options:
-      source: cloud:xenial-queens/proposed
+      source: cloud:xenial-queens
     to:
     - lxd:0

--- a/development/openstack-telemetry-xenial-queens/bundle.yaml
+++ b/development/openstack-telemetry-xenial-queens/bundle.yaml
@@ -119,7 +119,7 @@ services:
     charm: cs:~openstack-charmers-next/aodh
     num_units: 1
     options:
-      openstack-origin: cloud:xenial-queens/proposed
+      openstack-origin: cloud:xenial-queens
     to:
     - lxd:0
   ceilometer:
@@ -129,7 +129,7 @@ services:
     charm: cs:~openstack-charmers-next/ceilometer
     num_units: 1
     options:
-      openstack-origin: cloud:xenial-queens/proposed
+      openstack-origin: cloud:xenial-queens
     to:
     - lxd:2
   ceilometer-agent:
@@ -146,7 +146,7 @@ services:
     num_units: 3
     options:
       expected-osd-count: 3
-      source: cloud:xenial-queens/proposed
+      source: cloud:xenial-queens
     to:
     - lxd:1
     - lxd:2
@@ -159,7 +159,7 @@ services:
     num_units: 3
     options:
       osd-devices: /dev/sdb
-      source: cloud:xenial-queens/proposed
+      source: cloud:xenial-queens
     to:
     - '1'
     - '2'
@@ -171,7 +171,7 @@ services:
     charm: cs:~openstack-charmers-next/ceph-radosgw
     num_units: 1
     options:
-      source: cloud:xenial-queens/proposed
+      source: cloud:xenial-queens
     to:
     - lxd:0
   cinder:
@@ -182,7 +182,7 @@ services:
     num_units: 1
     options:
       worker-multiplier: 0.25
-      openstack-origin: cloud:xenial-queens/proposed
+      openstack-origin: cloud:xenial-queens
       block-device: None
       glance-api-version: 2
     to:
@@ -200,7 +200,7 @@ services:
     charm: cs:~openstack-charmers-next/glance
     num_units: 1
     options:
-      openstack-origin: cloud:xenial-queens/proposed
+      openstack-origin: cloud:xenial-queens
       worker-multiplier: 0.25
     to:
     - lxd:2
@@ -211,7 +211,7 @@ services:
     charm: cs:~openstack-charmers-next/keystone
     num_units: 1
     options:
-      openstack-origin: cloud:xenial-queens/proposed
+      openstack-origin: cloud:xenial-queens
       worker-multiplier: 0.25
     to:
     - lxd:3
@@ -233,7 +233,7 @@ services:
     charm: cs:~openstack-charmers-next/neutron-api
     num_units: 1
     options:
-      openstack-origin: cloud:xenial-queens/proposed
+      openstack-origin: cloud:xenial-queens
       flat-network-providers: physnet1
       neutron-security-groups: true
       worker-multiplier: 0.25
@@ -246,7 +246,7 @@ services:
     charm: cs:~openstack-charmers-next/neutron-gateway
     num_units: 1
     options:
-      openstack-origin: cloud:xenial-queens/proposed
+      openstack-origin: cloud:xenial-queens
       bridge-mappings: physnet1:br-ex
       data-port: br-ex:eno2
       worker-multiplier: 0.25
@@ -265,7 +265,7 @@ services:
     charm: cs:~openstack-charmers-next/nova-cloud-controller
     num_units: 1
     options:
-      openstack-origin: cloud:xenial-queens/proposed
+      openstack-origin: cloud:xenial-queens
       network-manager: Neutron
       worker-multiplier: 0.25
     to:
@@ -278,7 +278,7 @@ services:
     num_units: 3
     options:
       config-flags: default_ephemeral_format=ext4
-      openstack-origin: cloud:xenial-queens/proposed
+      openstack-origin: cloud:xenial-queens
       enable-live-migration: true
       enable-resize: true
       migration-auth-type: ssh
@@ -299,7 +299,7 @@ services:
     charm: cs:~openstack-charmers-next/openstack-dashboard
     num_units: 1
     options:
-      openstack-origin: cloud:xenial-queens/proposed
+      openstack-origin: cloud:xenial-queens
     to:
     - lxd:3
   rabbitmq-server:
@@ -309,7 +309,7 @@ services:
     charm: cs:~openstack-charmers-next/rabbitmq-server
     num_units: 1
     options:
-      source: cloud:xenial-queens/proposed
+      source: cloud:xenial-queens
     to:
     - lxd:0
   gnocchi:
@@ -319,7 +319,7 @@ services:
     num_units: 1
     charm: cs:~openstack-charmers-next/gnocchi
     options:
-      openstack-origin: cloud:xenial-queens/proposed
+      openstack-origin: cloud:xenial-queens
     to:
     - lxd:1
   memcached:


### PR DESCRIPTION
Bionic main and xenial-queens UCA have the necessary bits.

Developing towards the proposed archives may lead to
inconsistent results as bits there may change or indeed
disappear before they hit main archives.