### PR TITLE
Fix neutron-openvswitch relation in Octavia overlays

### DIFF
--- a/development/overlays/loadbalancer-octavia.yaml
+++ b/development/overlays/loadbalancer-octavia.yaml
@@ -42,7 +42,7 @@ relations:
   - barbican:amqp
 - - neutron-api:neutron-load-balancer
   - octavia:neutron-api
-- - neutron-openvswitch:neutron-control
+- - neutron-openvswitch:neutron-plugin
   - octavia:neutron-openvswitch
 - - openstack-dashboard:dashboard-plugin
   - octavia-dashboard:dashboard

--- a/stable/overlays/loadbalancer-octavia.yaml
+++ b/stable/overlays/loadbalancer-octavia.yaml
@@ -42,7 +42,7 @@ relations:
   - barbican:amqp
 - - neutron-api:neutron-load-balancer
   - octavia:neutron-api
-- - neutron-openvswitch:neutron-control
+- - neutron-openvswitch:neutron-plugin
   - octavia:neutron-openvswitch
 - - openstack-dashboard:dashboard-plugin
   - octavia-dashboard:dashboard


### PR DESCRIPTION
A late amendment to the relation type between Octavia
and Neutron OpenvSwitch did not make it into the bundles.