### PR TITLE
missed these mistake in the last commit

### DIFF
--- a/development/openstack-lxd-xenial-mitaka/bundle.yaml
+++ b/development/openstack-lxd-xenial-mitaka/bundle.yaml
@@ -193,7 +193,6 @@ services:
       enable-live-migration: true
       enable-resize: true
       migration-auth-type: ssh
-      openstack-origin: cloud:xenial-mitaka
       virt-type: lxd
     to:
     - '1'
@@ -211,8 +210,6 @@ services:
       gui-y: '-250'
     charm: cs:~openstack-charmers-next/openstack-dashboard
     num_units: 1
-    options:
-      openstack-origin: cloud:xenial-mitaka
     to:
     - lxd:3
   rabbitmq-server:


### PR DESCRIPTION
remove references to xenial-mitaka as there is no such cloud pocket with that name (mitaka is default for xenial)