### PR TITLE
Disable bindings in openstack base virt overlay

### DIFF
--- a/stable/overlays/openstack-base-virt-overlay.yaml
+++ b/stable/overlays/openstack-base-virt-overlay.yaml
@@ -2,6 +2,8 @@ machines: {}
 applications:
   ceph-osd:
     to: []
+    bindings:
+      "": ""
     storage:
       osd-devices: 20GB
   neutron-gateway:
@@ -10,33 +12,59 @@ applications:
       data-port:
       openstack-origin: cloud:bionic-rocky
     to: []
+    bindings:
+      "": ""
   ceph-mon:
     to: []
+    bindings:
+      "": ""
   ceph-radosgw:
     to: []
+    bindings:
+      "": ""
   cinder:
     expose: True
     to: []
+    bindings:
+      "": ""
   glance:
     expose: True
     to: []
+    bindings:
+      "": ""
   keystone:
     expose: True
     to: []
+    bindings:
+      "": ""
   mysql:
     to: []
+    bindings:
+      "": ""
   neutron-api:
     expose: True
     to: []
+    bindings:
+      "": ""
   nova-cloud-controller:
     expose: True
     to: []
+    bindings:
+      "": ""
   nova-compute:
     annotations:
     to: []
+    bindings:
+      "": ""
   openstack-dashboard:
     expose: True
     to: []
+    bindings:
+      "": ""
   rabbitmq-server:
     to: []
+    bindings:
+      "": ""
   ntp:
+    bindings:
+      "": ""


### PR DESCRIPTION
Commit 5d301f8f3a0c8b3b0d70fa8ab02099ac27b68db4 introduced base
bundle.yaml bindings support, enabling deployment of applications
to the public-space space. This caused problems with the existing
openstack-base-virt-overlay.yaml so here we bring the virt overlay
up to speed by disabling bindings.