### PR TITLE
Apply memory constraint to nova-compute application

### DIFF
--- a/stable/overlays/openstack-base-virt-overlay.yaml
+++ b/stable/overlays/openstack-base-virt-overlay.yaml
@@ -54,6 +54,7 @@ applications:
   nova-compute:
     annotations:
     to: []
+    constraints: mem=4G
     bindings:
       "": ""
   openstack-dashboard:


### PR DESCRIPTION
I'm requesting that we give more memory to the compute nodes so we give the user a better experience when launching a few test instances. Without this change these nodes only get 1.5GiB.