### PR TITLE
Update OVN overlays bridge-interface-mappings

### DIFF
--- a/development/openstack-base-eoan-train-mysql8-ovn/bundle.yaml
+++ b/development/openstack-base-eoan-train-mysql8-ovn/bundle.yaml
@@ -1,7 +1,7 @@
 # Open Virtual Network (OVN) - requires Train or later
 #
 # NOTE: Please review the value for the configuration option
-#       `interface-bridge-mappings` for the `ovn-chassis` charm.
+#       `bridge-interface-mappings` for the `ovn-chassis` charm.
 #       Refer to the [Open Virtual Network (OVN)](https://docs.openstack.org/project-deploy-guide/charm-deployment-guide/latest/app-ovn.html)
 #       section of the [OpenStack Charms Deployment Guide](https://docs.openstack.org/project-deploy-guide/charm-deployment-guide/latest/)
 #       for more information.
@@ -315,12 +315,12 @@ applications:
   ovn-chassis:
     charm: cs:~openstack-charmers/ovn-chassis
     comment: |
-      Please update the `interface-bridge-mappings` to values suitable for the
+      Please update the `bridge-interface-mappings` to values suitable for the
       hardware used in your deployment.  See the referenced documentation at
       the top of this file.
     options:
       ovn-bridge-mappings: physnet1:br-provider
-      interface-bridge-mappings: 00:00:5e:00:00:42:br-provider 00:00:5e:00:00:51:br-provider
+      bridge-interface-mappings: br-provider:00:00:5e:00:00:42 br-provider:00:00:5e:00:00:51
   vault:
     charm: cs:vault
     num_units: 1

--- a/development/overlays/openstack-base-ovn.yaml
+++ b/development/overlays/openstack-base-ovn.yaml
@@ -1,7 +1,7 @@
 # Open Virtual Network (OVN) - requires Train or later
 #
 # NOTE: Please review the value for the configuration option
-#       `interface-bridge-mappings` for the `ovn-chassis` charm.
+#       `bridge-interface-mappings` for the `ovn-chassis` charm.
 #       Refer to the [Open Virtual Network (OVN)](https://docs.openstack.org/project-deploy-guide/charm-deployment-guide/latest/app-ovn.html)
 #       section of the [OpenStack Charms Deployment Guide](https://docs.openstack.org/project-deploy-guide/charm-deployment-guide/latest/)
 #       for more information.
@@ -86,12 +86,12 @@ applications:
   ovn-chassis:
     charm: cs:~openstack-charmers-next/ovn-chassis
     comment: |
-      Please update the `interface-bridge-mappings` to values suitable for the
+      Please update the `bridge-interface-mappings` to values suitable for the
       hardware used in your deployment.  See the referenced documentation at
       the top of this file.
     options:
       ovn-bridge-mappings: physnet1:br-provider
-      interface-bridge-mappings: 00:00:5e:00:00:42:br-provider 00:00:5e:00:00:51:br-provider
+      bridge-interface-mappings: br-provider:00:00:5e:00:00:42 br-provider:00:00:5e:00:00:51
   vault:
     charm: cs:~openstack-charmers-next/vault
     num_units: 1

--- a/stable/overlays/openstack-base-ovn.yaml
+++ b/stable/overlays/openstack-base-ovn.yaml
@@ -1,7 +1,7 @@
 # Open Virtual Network (OVN) - requires Train or later
 #
 # NOTE: Please review the value for the configuration option
-#       `interface-bridge-mappings` for the `ovn-chassis` charm.
+#       `bridge-interface-mappings` for the `ovn-chassis` charm.
 #       Refer to the [Open Virtual Network (OVN)](https://docs.openstack.org/project-deploy-guide/charm-deployment-guide/latest/app-ovn.html)
 #       section of the [OpenStack Charms Deployment Guide](https://docs.openstack.org/project-deploy-guide/charm-deployment-guide/latest/)
 #       for more information.
@@ -86,12 +86,12 @@ applications:
   ovn-chassis:
     charm: cs:~openstack-charmers/ovn-chassis
     comment: |
-      Please update the `interface-bridge-mappings` to values suitable for the
+      Please update the `bridge-interface-mappings` to values suitable for the
       hardware used in your deployment.  See the referenced documentation at
       the top of this file.
     options:
       ovn-bridge-mappings: physnet1:br-provider
-      interface-bridge-mappings: 00:00:5e:00:00:42:br-provider 00:00:5e:00:00:51:br-provider
+      bridge-interface-mappings: br-provider:00:00:5e:00:00:42 br-provider:00:00:5e:00:00:51
   vault:
     charm: cs:vault
     num_units: 1


### PR DESCRIPTION
On the back of openstack-charmers/charm-layer-ovn#6 and LP: #1850956
we changed the OVN Chassis charms to align with previous networking
charms wrt. how interfaces are mapped to bridges.  Update overlays
to use the changed configuration option.