### PR TITLE
Add ubuntu-lite bundles that validate parallel series upgrade

### DIFF
--- a/development/shared/test-requirements.txt
+++ b/development/shared/test-requirements.txt
@@ -1,2 +1,4 @@
 # zaza
 git+https://github.com/openstack-charmers/zaza.git#egg=zaza
+# zaza.openstack
+git+https://github.com/openstack-charmers/zaza-openstack-tests.git#egg=zaza.openstack

--- a/development/ubuntu-lite-series-upgrade-bionic/README.md
+++ b/development/ubuntu-lite-series-upgrade-bionic/README.md
@@ -1,0 +1,3 @@
+# Basic Ubuntu Series Upgrade bundle
+
+This bundle and test set is designed to validate series upgrade using Juju.

--- a/development/ubuntu-lite-series-upgrade-bionic/bundle.yaml
+++ b/development/ubuntu-lite-series-upgrade-bionic/bundle.yaml
@@ -1,0 +1,6 @@
+series: bionic
+
+applications:
+  ubuntu-lite:
+    charm: cs:~chris.macnaughton/test-ubuntu
+    num_units: 3

--- a/development/ubuntu-lite-series-upgrade-bionic/test-requirements.txt
+++ b/development/ubuntu-lite-series-upgrade-bionic/test-requirements.txt
@@ -1,0 +1,1 @@
+../shared/test-requirements.txt

--- a/development/ubuntu-lite-series-upgrade-bionic/tests/bundles/bundle.yaml
+++ b/development/ubuntu-lite-series-upgrade-bionic/tests/bundles/bundle.yaml
@@ -1,0 +1,1 @@
+../../bundle.yaml

--- a/development/ubuntu-lite-series-upgrade-bionic/tests/tests.yaml
+++ b/development/ubuntu-lite-series-upgrade-bionic/tests/tests.yaml
@@ -1,0 +1,7 @@
+configure: []
+dev_bundles: []
+gate_bundles:
+  - bundle
+smoke_bundles: []
+tests:
+  - zaza.openstack.charm_tests.series_upgrade.parallel_tests.BionicFocalSeriesUpgradeUbuntu

--- a/development/ubuntu-lite-series-upgrade-bionic/tox.ini
+++ b/development/ubuntu-lite-series-upgrade-bionic/tox.ini
@@ -1,0 +1,1 @@
+../shared/tox.ini

--- a/development/ubuntu-lite-series-upgrade-trusty/README.md
+++ b/development/ubuntu-lite-series-upgrade-trusty/README.md
@@ -1,0 +1,3 @@
+# Basic Ubuntu Series Upgrade bundle
+
+This bundle and test set is designed to validate series upgrade using Juju.

--- a/development/ubuntu-lite-series-upgrade-trusty/bundle.yaml
+++ b/development/ubuntu-lite-series-upgrade-trusty/bundle.yaml
@@ -1,0 +1,6 @@
+series: trusty
+
+applications:
+  ubuntu-lite:
+    charm: cs:~chris.macnaughton/test-ubuntu
+    num_units: 3

--- a/development/ubuntu-lite-series-upgrade-trusty/test-requirements.txt
+++ b/development/ubuntu-lite-series-upgrade-trusty/test-requirements.txt
@@ -1,0 +1,1 @@
+../shared/test-requirements.txt

--- a/development/ubuntu-lite-series-upgrade-trusty/tests/bundles/bundle.yaml
+++ b/development/ubuntu-lite-series-upgrade-trusty/tests/bundles/bundle.yaml
@@ -1,0 +1,1 @@
+../../bundle.yaml

--- a/development/ubuntu-lite-series-upgrade-trusty/tests/tests.yaml
+++ b/development/ubuntu-lite-series-upgrade-trusty/tests/tests.yaml
@@ -1,0 +1,7 @@
+configure: []
+dev_bundles: []
+gate_bundles:
+  - bundle
+smoke_bundles: []
+tests:
+  - zaza.openstack.charm_tests.series_upgrade.parallel_tests.TrustyXenialSeriesUpgradeUbuntu

--- a/development/ubuntu-lite-series-upgrade-trusty/tox.ini
+++ b/development/ubuntu-lite-series-upgrade-trusty/tox.ini
@@ -1,0 +1,1 @@
+../shared/tox.ini

--- a/development/ubuntu-lite-series-upgrade-xenial/README.md
+++ b/development/ubuntu-lite-series-upgrade-xenial/README.md
@@ -1,0 +1,3 @@
+# Basic Ubuntu Series Upgrade bundle
+
+This bundle and test set is designed to validate series upgrade using Juju.

--- a/development/ubuntu-lite-series-upgrade-xenial/bundle.yaml
+++ b/development/ubuntu-lite-series-upgrade-xenial/bundle.yaml
@@ -1,0 +1,6 @@
+series: xenial
+
+applications:
+  ubuntu-lite:
+    charm: cs:~chris.macnaughton/test-ubuntu
+    num_units: 3

--- a/development/ubuntu-lite-series-upgrade-xenial/test-requirements.txt
+++ b/development/ubuntu-lite-series-upgrade-xenial/test-requirements.txt
@@ -1,0 +1,1 @@
+../shared/test-requirements.txt

--- a/development/ubuntu-lite-series-upgrade-xenial/tests/bundles/bundle.yaml
+++ b/development/ubuntu-lite-series-upgrade-xenial/tests/bundles/bundle.yaml
@@ -1,0 +1,1 @@
+../../bundle.yaml

--- a/development/ubuntu-lite-series-upgrade-xenial/tests/tests.yaml
+++ b/development/ubuntu-lite-series-upgrade-xenial/tests/tests.yaml
@@ -1,0 +1,7 @@
+configure: []
+dev_bundles: []
+gate_bundles:
+  - bundle
+smoke_bundles: []
+tests:
+  - zaza.openstack.charm_tests.series_upgrade.parallel_tests.XenialBionicSeriesUpgradeUbuntu

--- a/development/ubuntu-lite-series-upgrade-xenial/tox.ini
+++ b/development/ubuntu-lite-series-upgrade-xenial/tox.ini
@@ -1,0 +1,1 @@
+../shared/tox.ini


### PR DESCRIPTION
An example of this running the xenial --> bionic upgrade

```bash
2020-04-15 16:11:52 [INFO] ok
2020-04-15 16:11:52 [INFO] ----------------------------------------------------------------------
2020-04-15 16:11:52 [INFO] Ran 1 test in 875.331s
2020-04-15 16:11:52 [INFO] OK
2020-04-15 16:11:52 [INFO] Events:
  Deploy Bundle:
    Start: 1586958982.2283154
    Finish: 1586958992.1511385
    Elapsed Time: 9.922823190689087
    PCT Of Run Time: 2
  Prepare Environment:
    Start: 1586958964.061425
    Finish: 1586958982.2274125
    Elapsed Time: 18.165987491607666
    PCT Of Run Time: 2
  Test zaza.openstack.charm_tests.series_upgrade.parallel_tests.XenialBionicSeriesUpgradeUbuntu:
    Start: 1586959036.9020543
    Finish: 1586959912.5931423
    Elapsed Time: 875.6910879611969
    PCT Of Run Time: 93
  Wait for Deployment:
    Start: 1586958992.151174
    Finish: 1586959036.839397
    Elapsed Time: 44.688222885131836
    PCT Of Run Time: 5
Metadata: {}

________________________________________________________________ summary _________________________________________________________________
  func: commands succeeded
  congratulations :)
```