### PR TITLE
Release 20.05

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 sudo: false
 language: python
 python:
-    - "2.7"
-    - "3.4"
+    # Align with the latest two LTS versions of Ubuntu
+    - "3.5"
+    - "3.8"
 install: pip install tox-travis
 script: tox -e lint-light

--- a/development/ceph-base-bionic-luminous/bundle.yaml
+++ b/development/ceph-base-bionic-luminous/bundle.yaml
@@ -11,7 +11,7 @@ relations:
 - - ntp:juju-info
   - ceph-osd:juju-info
 series: bionic
-services:
+applications:
   ceph-mon:
     annotations:
       gui-x: '750'

--- a/development/ceph-base-bionic-mimic/bundle.yaml
+++ b/development/ceph-base-bionic-mimic/bundle.yaml
@@ -11,7 +11,7 @@ relations:
 - - ntp:juju-info
   - ceph-osd:juju-info
 series: bionic
-services:
+applications:
   ceph-mon:
     annotations:
       gui-x: '750'

--- a/development/ceph-base-bionic-nautilus/bundle.yaml
+++ b/development/ceph-base-bionic-nautilus/bundle.yaml
@@ -11,7 +11,7 @@ relations:
 - - ntp:juju-info
   - ceph-osd:juju-info
 series: bionic
-services:
+applications:
   ceph-mon:
     annotations:
       gui-x: '750'

--- a/development/ceph-base-cosmic-mimic/bundle.yaml
+++ b/development/ceph-base-cosmic-mimic/bundle.yaml
@@ -11,7 +11,7 @@ relations:
 - - ntp:juju-info
   - ceph-osd:juju-info
 series: cosmic
-services:
+applications:
   ceph-mon:
     annotations:
       gui-x: '750'

--- a/development/ceph-base-disco-mimic/bundle.yaml
+++ b/development/ceph-base-disco-mimic/bundle.yaml
@@ -9,7 +9,7 @@ relations:
 - - ceph-osd:mon
   - ceph-mon:osd
 series: disco
-services:
+applications:
   ceph-mon:
     annotations:
       gui-x: '750'

--- a/development/ceph-base-eoan-nautilus/bundle.yaml
+++ b/development/ceph-base-eoan-nautilus/bundle.yaml
@@ -9,7 +9,7 @@ relations:
 - - ceph-osd:mon
   - ceph-mon:osd
 series: eoan
-services:
+applications:
   ceph-mon:
     annotations:
       gui-x: '750'

--- a/development/ceph-base-focal-octopus/bundle.yaml
+++ b/development/ceph-base-focal-octopus/bundle.yaml
@@ -9,7 +9,7 @@ relations:
 - - ceph-osd:mon
   - ceph-mon:osd
 series: focal
-services:
+applications:
   ceph-mon:
     annotations:
       gui-x: '750'

--- a/development/ceph-base-xenial-jewel/bundle.yaml
+++ b/development/ceph-base-xenial-jewel/bundle.yaml
@@ -11,7 +11,7 @@ relations:
 - - ntp:juju-info
   - ceph-osd:juju-info
 series: xenial
-services:
+applications:
   ceph-mon:
     annotations:
       gui-x: '750'

--- a/development/ceph-base-xenial-luminous/bundle.yaml
+++ b/development/ceph-base-xenial-luminous/bundle.yaml
@@ -11,7 +11,7 @@ relations:
 - - ntp:juju-info
   - ceph-osd:juju-info
 series: xenial
-services:
+applications:
   ceph-mon:
     annotations:
       gui-x: '750'

--- a/development/openstack-base-bionic-queens/bundle.yaml
+++ b/development/openstack-base-bionic-queens/bundle.yaml
@@ -83,7 +83,7 @@ relations:
 - - ceph-radosgw:identity-service
   - keystone:identity-service
 series: bionic
-services:
+applications:
   ceph-mon:
     annotations:
       gui-x: '750'

--- a/development/openstack-base-bionic-rocky/bundle.yaml
+++ b/development/openstack-base-bionic-rocky/bundle.yaml
@@ -85,7 +85,7 @@ relations:
 - - ceph-radosgw:identity-service
   - keystone:identity-service
 series: bionic
-services:
+applications:
   ceph-mon:
     annotations:
       gui-x: '750'

--- a/development/openstack-base-bionic-stein/bundle.yaml
+++ b/development/openstack-base-bionic-stein/bundle.yaml
@@ -93,7 +93,7 @@ relations:
 - - ceph-radosgw:identity-service
   - keystone:identity-service
 series: bionic
-services:
+applications:
   ceph-mon:
     annotations:
       gui-x: '750'

--- a/development/openstack-base-bionic-train/bundle.yaml
+++ b/development/openstack-base-bionic-train/bundle.yaml
@@ -99,7 +99,7 @@ relations:
 - - placement
   - nova-cloud-controller
 series: bionic
-services:
+applications:
   ceph-mon:
     annotations:
       gui-x: '750'

--- a/development/openstack-base-bionic-ussuri/bundle.yaml
+++ b/development/openstack-base-bionic-ussuri/bundle.yaml
@@ -99,7 +99,7 @@ relations:
 - - placement
   - nova-cloud-controller
 series: bionic
-services:
+applications:
   ceph-mon:
     annotations:
       gui-x: '750'

--- a/development/openstack-base-cosmic-rocky/bundle.yaml
+++ b/development/openstack-base-cosmic-rocky/bundle.yaml
@@ -85,7 +85,7 @@ relations:
 - - ceph-radosgw:identity-service
   - keystone:identity-service
 series: cosmic
-services:
+applications:
   ceph-mon:
     annotations:
       gui-x: '750'

--- a/development/openstack-base-disco-stein/bundle.yaml
+++ b/development/openstack-base-disco-stein/bundle.yaml
@@ -85,7 +85,7 @@ relations:
 - - ceph-radosgw:identity-service
   - keystone:identity-service
 series: disco
-services:
+applications:
   ceph-mon:
     annotations:
       gui-x: '750'

--- a/development/openstack-base-eoan-train/bundle.yaml
+++ b/development/openstack-base-eoan-train/bundle.yaml
@@ -99,7 +99,7 @@ relations:
 - - placement
   - nova-cloud-controller
 series: eoan
-services:
+applications:
   ceph-mon:
     annotations:
       gui-x: '750'

--- a/development/openstack-base-spaces/bundle.yaml
+++ b/development/openstack-base-spaces/bundle.yaml
@@ -81,7 +81,7 @@ relations:
 - - ceph-radosgw:identity-service
   - keystone:identity-service
 series: xenial
-services:
+applications:
   ceph-mon:
     annotations:
       gui-x: '750'

--- a/development/openstack-base-xenial-mitaka/bundle.yaml
+++ b/development/openstack-base-xenial-mitaka/bundle.yaml
@@ -83,7 +83,7 @@ relations:
 - - ceph-radosgw:identity-service
   - keystone:identity-service
 series: xenial
-services:
+applications:
   ceph-mon:
     annotations:
       gui-x: '750'

--- a/development/openstack-base-xenial-newton/bundle.yaml
+++ b/development/openstack-base-xenial-newton/bundle.yaml
@@ -83,7 +83,7 @@ relations:
 - - ceph-radosgw:identity-service
   - keystone:identity-service
 series: xenial
-services:
+applications:
   ceph-mon:
     annotations:
       gui-x: '750'

--- a/development/openstack-base-xenial-ocata/bundle.yaml
+++ b/development/openstack-base-xenial-ocata/bundle.yaml
@@ -83,7 +83,7 @@ relations:
 - - ceph-radosgw:identity-service
   - keystone:identity-service
 series: xenial
-services:
+applications:
   ceph-mon:
     annotations:
       gui-x: '750'

--- a/development/openstack-base-xenial-pike/bundle.yaml
+++ b/development/openstack-base-xenial-pike/bundle.yaml
@@ -83,7 +83,7 @@ relations:
 - - ceph-radosgw:identity-service
   - keystone:identity-service
 series: xenial
-services:
+applications:
   ceph-mon:
     annotations:
       gui-x: '750'

--- a/development/openstack-base-xenial-queens/bundle.yaml
+++ b/development/openstack-base-xenial-queens/bundle.yaml
@@ -83,7 +83,7 @@ relations:
 - - ceph-radosgw:identity-service
   - keystone:identity-service
 series: xenial
-services:
+applications:
   ceph-mon:
     annotations:
       gui-x: '750'

--- a/development/openstack-dpdk/bundle.yaml
+++ b/development/openstack-dpdk/bundle.yaml
@@ -78,7 +78,7 @@ relations:
 - - ceph-radosgw:identity-service
   - keystone:identity-service
 series: xenial
-services:
+applications:
   ceph:
     annotations:
       gui-x: '750'

--- a/development/openstack-lxd-bionic-queens/bundle.yaml
+++ b/development/openstack-lxd-bionic-queens/bundle.yaml
@@ -69,7 +69,7 @@ relations:
 - - nova-compute:lxd
   - lxd:lxd
 series: bionic
-services:
+applications:
   ceph-mon:
     annotations:
       gui-x: '750'

--- a/development/openstack-lxd-bionic-rocky/bundle.yaml
+++ b/development/openstack-lxd-bionic-rocky/bundle.yaml
@@ -69,7 +69,7 @@ relations:
 - - nova-compute:lxd
   - lxd:lxd
 series: bionic
-services:
+applications:
   ceph-mon:
     annotations:
       gui-x: '750'

--- a/development/openstack-lxd-bionic-stein/bundle.yaml
+++ b/development/openstack-lxd-bionic-stein/bundle.yaml
@@ -69,7 +69,7 @@ relations:
 - - nova-compute:lxd
   - lxd:lxd
 series: bionic
-services:
+applications:
   ceph-mon:
     annotations:
       gui-x: '750'

--- a/development/openstack-lxd-cosmic-rocky/bundle.yaml
+++ b/development/openstack-lxd-cosmic-rocky/bundle.yaml
@@ -69,7 +69,7 @@ relations:
 - - nova-compute:lxd
   - lxd:lxd
 series: cosmic
-services:
+applications:
   ceph-mon:
     annotations:
       gui-x: '750'

--- a/development/openstack-lxd-disco-stein/bundle.yaml
+++ b/development/openstack-lxd-disco-stein/bundle.yaml
@@ -69,7 +69,7 @@ relations:
 - - nova-compute:lxd
   - lxd:lxd
 series: disco
-services:
+applications:
   ceph-mon:
     annotations:
       gui-x: '750'

--- a/development/openstack-lxd-xenial-mitaka/bundle.yaml
+++ b/development/openstack-lxd-xenial-mitaka/bundle.yaml
@@ -69,7 +69,7 @@ relations:
 - - nova-compute:lxd
   - lxd:lxd
 series: xenial
-services:
+applications:
   ceph-mon:
     annotations:
       gui-x: '750'

--- a/development/openstack-lxd-xenial-queens/bundle.yaml
+++ b/development/openstack-lxd-xenial-queens/bundle.yaml
@@ -69,7 +69,7 @@ relations:
 - - nova-compute:lxd
   - lxd:lxd
 series: xenial
-services:
+applications:
   ceph-mon:
     annotations:
       gui-x: '750'

--- a/development/openstack-refstack-bionic-queens/bundle.yaml
+++ b/development/openstack-refstack-bionic-queens/bundle.yaml
@@ -87,7 +87,7 @@ relations:
 - - swift-proxy:swift-storage
   - swift-storage:swift-storage
 series: bionic
-services:
+applications:
   ceph-mon:
     annotations:
       gui-x: '750'

--- a/development/openstack-refstack-cosmic-rocky/bundle.yaml
+++ b/development/openstack-refstack-cosmic-rocky/bundle.yaml
@@ -87,7 +87,7 @@ relations:
 - - swift-proxy:swift-storage
   - swift-storage:swift-storage
 series: cosmic
-services:
+applications:
   ceph-mon:
     annotations:
       gui-x: '750'

--- a/development/openstack-refstack-xenial-ocata-ppc64el-alt/bundle.yaml
+++ b/development/openstack-refstack-xenial-ocata-ppc64el-alt/bundle.yaml
@@ -105,7 +105,7 @@ relations:
 - - swift-proxy:swift-storage
   - swift-storage:swift-storage
 series: xenial
-services:
+applications:
   aodh:
     annotations:
       gui-x: '1500'

--- a/development/openstack-refstack-xenial-ocata/bundle.yaml
+++ b/development/openstack-refstack-xenial-ocata/bundle.yaml
@@ -101,7 +101,7 @@ relations:
 - - swift-proxy:swift-storage
   - swift-storage:swift-storage
 series: xenial
-services:
+applications:
   aodh:
     annotations:
       gui-x: '1500'

--- a/development/openstack-refstack-xenial-pike-ppc64el-alt/bundle.yaml
+++ b/development/openstack-refstack-xenial-pike-ppc64el-alt/bundle.yaml
@@ -105,7 +105,7 @@ relations:
 - - swift-proxy:swift-storage
   - swift-storage:swift-storage
 series: xenial
-services:
+applications:
   aodh:
     annotations:
       gui-x: '1500'

--- a/development/openstack-refstack-xenial-pike/bundle.yaml
+++ b/development/openstack-refstack-xenial-pike/bundle.yaml
@@ -101,7 +101,7 @@ relations:
 - - swift-proxy:swift-storage
   - swift-storage:swift-storage
 series: xenial
-services:
+applications:
   aodh:
     annotations:
       gui-x: '1500'

--- a/development/openstack-telemetry-bionic-queens/bundle.yaml
+++ b/development/openstack-telemetry-bionic-queens/bundle.yaml
@@ -113,7 +113,7 @@ relations:
 - - ceilometer:identity-credentials
   - keystone:identity-credentials
 series: bionic
-services:
+applications:
   aodh:
     annotations:
       gui-x: '1500'

--- a/development/openstack-telemetry-bionic-rocky/bundle.yaml
+++ b/development/openstack-telemetry-bionic-rocky/bundle.yaml
@@ -113,7 +113,7 @@ relations:
 - - ceilometer:identity-credentials
   - keystone:identity-credentials
 series: bionic
-services:
+applications:
   aodh:
     annotations:
       gui-x: '1500'

--- a/development/openstack-telemetry-bionic-stein/bundle.yaml
+++ b/development/openstack-telemetry-bionic-stein/bundle.yaml
@@ -121,7 +121,7 @@ relations:
 - - ceilometer:identity-credentials
   - keystone:identity-credentials
 series: bionic
-services:
+applications:
   aodh:
     annotations:
       gui-x: '1500'

--- a/development/openstack-telemetry-bionic-train/bundle.yaml
+++ b/development/openstack-telemetry-bionic-train/bundle.yaml
@@ -127,7 +127,7 @@ relations:
 - - placement
   - nova-cloud-controller
 series: bionic
-services:
+applications:
   aodh:
     annotations:
       gui-x: '1500'

--- a/development/openstack-telemetry-bionic-ussuri/bundle.yaml
+++ b/development/openstack-telemetry-bionic-ussuri/bundle.yaml
@@ -127,7 +127,7 @@ relations:
 - - placement
   - nova-cloud-controller
 series: bionic
-services:
+applications:
   aodh:
     annotations:
       gui-x: '1500'

--- a/development/openstack-telemetry-cosmic-rocky/bundle.yaml
+++ b/development/openstack-telemetry-cosmic-rocky/bundle.yaml
@@ -113,7 +113,7 @@ relations:
 - - ceilometer:identity-credentials
   - keystone:identity-credentials
 series: cosmic
-services:
+applications:
   aodh:
     annotations:
       gui-x: '1500'

--- a/development/openstack-telemetry-disco-stein/bundle.yaml
+++ b/development/openstack-telemetry-disco-stein/bundle.yaml
@@ -109,7 +109,7 @@ relations:
 - - ceilometer:identity-credentials
   - keystone:identity-credentials
 series: disco
-services:
+applications:
   aodh:
     annotations:
       gui-x: '1500'

--- a/development/openstack-telemetry-eoan-train/bundle.yaml
+++ b/development/openstack-telemetry-eoan-train/bundle.yaml
@@ -127,7 +127,7 @@ relations:
 - - placement
   - nova-cloud-controller
 series: eoan
-services:
+applications:
   aodh:
     annotations:
       gui-x: '1500'

--- a/development/openstack-telemetry-xenial-mitaka/bundle.yaml
+++ b/development/openstack-telemetry-xenial-mitaka/bundle.yaml
@@ -103,7 +103,7 @@ relations:
 - - aodh:amqp
   - rabbitmq-server:amqp
 series: xenial
-services:
+applications:
   aodh:
     annotations:
       gui-x: '1500'

--- a/development/openstack-telemetry-xenial-newton/bundle.yaml
+++ b/development/openstack-telemetry-xenial-newton/bundle.yaml
@@ -103,7 +103,7 @@ relations:
 - - aodh:amqp
   - rabbitmq-server:amqp
 series: xenial
-services:
+applications:
   aodh:
     annotations:
       gui-x: '1500'

--- a/development/openstack-telemetry-xenial-ocata/bundle.yaml
+++ b/development/openstack-telemetry-xenial-ocata/bundle.yaml
@@ -103,7 +103,7 @@ relations:
 - - aodh:amqp
   - rabbitmq-server:amqp
 series: xenial
-services:
+applications:
   aodh:
     annotations:
       gui-x: '1500'

--- a/development/openstack-telemetry-xenial-pike/bundle.yaml
+++ b/development/openstack-telemetry-xenial-pike/bundle.yaml
@@ -103,7 +103,7 @@ relations:
 - - aodh:amqp
   - rabbitmq-server:amqp
 series: xenial
-services:
+applications:
   aodh:
     annotations:
       gui-x: '1500'

--- a/development/openstack-telemetry-xenial-queens/bundle.yaml
+++ b/development/openstack-telemetry-xenial-queens/bundle.yaml
@@ -113,7 +113,7 @@ relations:
 - - ceilometer:identity-credentials
   - keystone:identity-credentials
 series: xenial
-services:
+applications:
   aodh:
     annotations:
       gui-x: '1500'

--- a/development/shared/neutron-ext-net-ksv3
+++ b/development/shared/neutron-ext-net-ksv3
@@ -37,7 +37,7 @@ if __name__ == '__main__':
                       dest="floating_range", action="store", default=None)
     parser.add_option("--network-type",
                       help="Network type.",
-                      dest="network_type", action="store", default='gre')
+                      dest="network_type", action="store", default='geneve')
     parser.add_option(
         "--physical-network",
         help="Physical network if network type is 'vlan' or 'flat'.",

--- a/development/shared/neutron-ext-net-ksv3
+++ b/development/shared/neutron-ext-net-ksv3
@@ -37,7 +37,7 @@ if __name__ == '__main__':
                       dest="floating_range", action="store", default=None)
     parser.add_option("--network-type",
                       help="Network type.",
-                      dest="network_type", action="store", default='geneve')
+                      dest="network_type", action="store", default='gre')
     parser.add_option(
         "--physical-network",
         help="Physical network if network type is 'vlan' or 'flat'.",

--- a/stable/ceph-base/README.md
+++ b/stable/ceph-base/README.md
@@ -1,6 +1,6 @@
 # Basic Ceph Cluster
 
-This example bundle deploys a Ceph (Luminous) cluster on Ubuntu 18.04 LTS.
+This example bundle deploys a Ceph (Octopus) cluster on Ubuntu 20.04 LTS.
 
 ## Requirements
 

--- a/stable/ceph-base/bundle.yaml
+++ b/stable/ceph-base/bundle.yaml
@@ -9,7 +9,7 @@ relations:
 - - ceph-osd:mon
   - ceph-mon:osd
 series: focal
-services:
+applications:
   ceph-mon:
     annotations:
       gui-x: '750'

--- a/stable/ceph-base/bundle.yaml
+++ b/stable/ceph-base/bundle.yaml
@@ -1,3 +1,30 @@
+applications:
+  ceph-mon:
+    annotations:
+      gui-x: '750'
+      gui-y: '500'
+    charm: cs:ceph-mon-48
+    num_units: 3
+    options:
+      expected-osd-count: 3
+      source: distro
+    to:
+    - lxd:0
+    - lxd:1
+    - lxd:2
+  ceph-osd:
+    annotations:
+      gui-x: '1000'
+      gui-y: '500'
+    charm: cs:ceph-osd-303
+    num_units: 3
+    options:
+      osd-devices: /dev/sdb
+      source: distro
+    to:
+    - '0'
+    - '1'
+    - '2'
 machines:
   '0':
     series: focal
@@ -9,30 +36,3 @@ relations:
 - - ceph-osd:mon
   - ceph-mon:osd
 series: focal
-applications:
-  ceph-mon:
-    annotations:
-      gui-x: '750'
-      gui-y: '500'
-    charm: cs:~openstack-charmers-next/ceph-mon
-    num_units: 3
-    options:
-      expected-osd-count: 3
-      source: distro
-    to:
-    - 'lxd:0'
-    - 'lxd:1'
-    - 'lxd:2'
-  ceph-osd:
-    annotations:
-      gui-x: '1000'
-      gui-y: '500'
-    charm: cs:~openstack-charmers-next/ceph-osd
-    num_units: 3
-    options:
-      osd-devices: /dev/sdb
-      source: distro
-    to:
-    - '0'
-    - '1'
-    - '2'

--- a/stable/ceph-base/bundle.yaml
+++ b/stable/ceph-base/bundle.yaml
@@ -1,47 +1,38 @@
 machines:
   '0':
-    series: bionic
+    series: focal
   '1':
-    series: bionic
+    series: focal
   '2':
-    series: bionic
+    series: focal
 relations:
 - - ceph-osd:mon
   - ceph-mon:osd
-- - ntp:juju-info
-  - ceph-osd:juju-info
-series: bionic
+series: focal
 services:
   ceph-mon:
     annotations:
       gui-x: '750'
       gui-y: '500'
-    charm: cs:ceph-mon-44
+    charm: cs:~openstack-charmers-next/ceph-mon
     num_units: 3
     options:
       expected-osd-count: 3
-      source: cloud:bionic-train
+      source: distro
     to:
-    - lxd:0
-    - lxd:1
-    - lxd:2
+    - 'lxd:0'
+    - 'lxd:1'
+    - 'lxd:2'
   ceph-osd:
     annotations:
       gui-x: '1000'
       gui-y: '500'
-    charm: cs:ceph-osd-294
-    comment: SET osd-devices to match your environment
+    charm: cs:~openstack-charmers-next/ceph-osd
     num_units: 3
     options:
       osd-devices: /dev/sdb
-      source: cloud:bionic-train
+      source: distro
     to:
     - '0'
     - '1'
     - '2'
-  ntp:
-    annotations:
-      gui-x: '1000'
-      gui-y: '0'
-    charm: cs:ntp-35
-    num_units: 0

--- a/stable/openstack-base/README.md
+++ b/stable/openstack-base/README.md
@@ -14,14 +14,6 @@ Certain configuration options within the bundle may need to be adjusted prior to
 
 For example, a section similar to this exists in the bundle.yaml file.  The third "column" are the values to set.  Some servers may not have eno2, they may have something like eth2 or some other network device name.  This needs to be adjusted prior to deployment.  The same principle holds for osd-devices.  The third column is a whitelist of devices to use for Ceph OSDs.  Adjust accordingly by editing bundle.yaml before deployment.
 
-```
-variables:
-  openstack-origin:    &openstack-origin     distro
-  data-port:           &data-port            br-ex:eno2
-  worker-multiplier:   &worker-multiplier    0.25
-  osd-devices:         &osd-devices          /dev/sdb /dev/vdb
-```
-
 Servers should have:
 
  - A minimum of 8GB of physical RAM.

--- a/stable/openstack-base/README.md
+++ b/stable/openstack-base/README.md
@@ -150,10 +150,13 @@ the bundle.
   system without first installing the ``python-keystoneclient`` and
   ``python-neutronclient`` deb packages.
 
+> **NOTE**: The network type required for OVN is geneve - the default for the 
+  neutron-ext-net scripts is currently gre.
+
 For the "external" network a shared router ('provider-router') will be used by
 all tenants for public access to instances. The syntax is:
 
-    ./neutron-ext-net-ksv3 --network-type flat \
+    ./neutron-ext-net-ksv3 --network-type geneve \
         -g <gateway-ip> -c <network-cidr> \
         -f <pool-start>:<pool-end> <network-name>
 
@@ -162,7 +165,7 @@ the internet. Here, we'll configure for a private cloud. The actual values will
 depend on the environment that the second network interface (on all the nodes)
 is connected to. For example:
 
-    ./neutron-ext-net-ksv3 --network-type flat \
+    ./neutron-ext-net-ksv3 --network-type geneve \
         -g 10.230.168.1 -c 10.230.168.0/21 \
         -f 10.230.168.10:10.230.175.254 ext_net
 

--- a/stable/openstack-base/README.md
+++ b/stable/openstack-base/README.md
@@ -106,12 +106,12 @@ command line. Install them now:
 
     sudo snap install openstackclients
 
-## Unlock vault
+## Unseal vault
 
-This release uses vault to secure keystone - vault needs to be unlocked before the configuration
-can be finalised and the cloud used. See the following documentation for unlock steps:
+This release uses vault to secure keystone - vault needs to be unsealed before the configuration
+can be finalised and the cloud used. See the following documentation for unseal steps:
 
-[Unlocking vault][vault-appendix]
+[Unsealing vault][vault-appendix]
 
 ## Access the cloud
 

--- a/stable/openstack-base/README.md
+++ b/stable/openstack-base/README.md
@@ -111,7 +111,7 @@ command line. Install them now:
 This release uses vault to secure keystone - vault needs to be unlocked before the configuration
 can be finalised and the cloud used. See the following documentation for unlock steps:
 
-[Unlocking vault][vault appendix]
+[Unlocking vault][vault-appendix]
 
 ## Access the cloud
 
@@ -309,5 +309,5 @@ Configuring and managing services for an OpenStack cloud is complex. See the
 [openstack-admin-guides]: http://docs.openstack.org/admin
 [openstack-bundles]: https://github.com/openstack-charmers/openstack-bundles/tree/master/stable/overlays
 [ubuntu-cloud-images]: http://cloud-images.ubuntu.com
-[Vault Unlock]: https://docs.openstack.org/project-deploy-guide/charm-deployment-guide/latest/app-vault.html
+[vault-appendix]: https://docs.openstack.org/project-deploy-guide/charm-deployment-guide/latest/app-vault.html
 

--- a/stable/openstack-base/bundle.yaml
+++ b/stable/openstack-base/bundle.yaml
@@ -342,7 +342,7 @@ applications:
   vault-mysql-router:
     charm: cs:~openstack-charmers-next/mysql-router
   vault:
-    charm: cs:vault
+    charm: cs:~openstack-charmers-next/vault
     num_units: 1
     to:
     - 'lxd:0'

--- a/stable/openstack-base/bundle.yaml
+++ b/stable/openstack-base/bundle.yaml
@@ -1,35 +1,39 @@
+# Open Virtual Network (OVN) - requires Train or later
+#
+# NOTE: Please review the value for the configuration option
+#       `bridge-interface-mappings` for the `ovn-chassis` charm.
+#       Refer to the [Open Virtual Network (OVN)](https://docs.openstack.org/project-deploy-guide/charm-deployment-guide/latest/app-ovn.html)
+#       section of the [OpenStack Charms Deployment Guide](https://docs.openstack.org/project-deploy-guide/charm-deployment-guide/latest/)
+#       for more information.
+---
+local_overlay_enabled: true
+series: focal
+# *** openstack-origin should be changed back to distro once this PPA is made redundant ***
+variables:
+  openstack-origin:    &openstack-origin     distro-proposed
+  data-port:           &data-port            br-ex:eno2
+  worker-multiplier:   &worker-multiplier    0.25
+  osd-devices:         &osd-devices          /dev/sdb /dev/vdb
+  expected-osd-count:  &expected-osd-count   3
+  expected-mon-count:  &expected-mon-count   3
 machines:
   '0':
-    series: bionic
+    series: focal
   '1':
-    series: bionic
+    series: focal
   '2':
-    series: bionic
-  '3':
-    series: bionic
+    series: focal
 relations:
 - - nova-compute:amqp
   - rabbitmq-server:amqp
-- - neutron-gateway:amqp
-  - rabbitmq-server:amqp
-- - keystone:shared-db
-  - mysql:shared-db
 - - nova-cloud-controller:identity-service
   - keystone:identity-service
 - - glance:identity-service
   - keystone:identity-service
 - - neutron-api:identity-service
   - keystone:identity-service
-- - neutron-openvswitch:neutron-plugin-api
-  - neutron-api:neutron-plugin-api
-- - neutron-api:shared-db
-  - mysql:shared-db
 - - neutron-api:amqp
   - rabbitmq-server:amqp
-- - neutron-gateway:neutron-plugin-api
-  - neutron-api:neutron-plugin-api
-- - glance:shared-db
-  - mysql:shared-db
 - - glance:amqp
   - rabbitmq-server:amqp
 - - nova-cloud-controller:image-service
@@ -40,18 +44,8 @@ relations:
   - nova-compute:cloud-compute
 - - nova-cloud-controller:amqp
   - rabbitmq-server:amqp
-- - nova-cloud-controller:quantum-network-service
-  - neutron-gateway:quantum-network-service
-- - nova-compute:neutron-plugin
-  - neutron-openvswitch:neutron-plugin
-- - neutron-openvswitch:amqp
-  - rabbitmq-server:amqp
 - - openstack-dashboard:identity-service
   - keystone:identity-service
-- - openstack-dashboard:shared-db
-  - mysql:shared-db
-- - nova-cloud-controller:shared-db
-  - mysql:shared-db
 - - nova-cloud-controller:neutron-api
   - neutron-api:neutron-api
 - - cinder:image-service
@@ -68,8 +62,6 @@ relations:
   - nova-compute:ceph
 - - nova-compute:ceph-access
   - cinder-ceph:ceph-access
-- - cinder:shared-db
-  - mysql:shared-db
 - - ceph-mon:client
   - cinder-ceph:ceph
 - - ceph-mon:client
@@ -78,204 +70,279 @@ relations:
   - ceph-mon:osd
 - - ntp:juju-info
   - nova-compute:juju-info
-- - ntp:juju-info
-  - neutron-gateway:juju-info
 - - ceph-radosgw:mon
   - ceph-mon:radosgw
 - - ceph-radosgw:identity-service
   - keystone:identity-service
 - - placement
-  - mysql
-- - placement
   - keystone
 - - placement
   - nova-cloud-controller
-series: bionic
-services:
+- - keystone:shared-db
+  - keystone-mysql-router:shared-db
+- - cinder:shared-db
+  - cinder-mysql-router:shared-db
+- - glance:shared-db
+  - glance-mysql-router:shared-db
+- - nova-cloud-controller:shared-db
+  - nova-mysql-router:shared-db
+- - neutron-api:shared-db
+  - neutron-mysql-router:shared-db
+- - openstack-dashboard:shared-db
+  - dashboard-mysql-router:shared-db
+- - placement:shared-db
+  - placement-mysql-router:shared-db
+- - vault:shared-db
+  - vault-mysql-router:shared-db
+- - keystone-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - cinder-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - nova-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - glance-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - neutron-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - dashboard-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - placement-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - vault-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - neutron-api-plugin-ovn:neutron-plugin
+  - neutron-api:neutron-plugin-api-subordinate
+- - ovn-central:certificates
+  - vault:certificates
+- - ovn-central:ovsdb-cms
+  - neutron-api-plugin-ovn:ovsdb-cms
+- - neutron-api:certificates
+  - vault:certificates
+- - ovn-chassis:nova-compute
+  - nova-compute:neutron-plugin
+- - ovn-chassis:certificates
+  - vault:certificates
+- - ovn-chassis:ovsdb
+  - ovn-central:ovsdb
+- - vault:certificates
+  - neutron-api-plugin-ovn:certificates
+- - vault:certificates
+  - cinder:certificates
+- - vault:certificates
+  - glance:certificates
+- - vault:certificates
+  - keystone:certificates
+- - vault:certificates
+  - nova-cloud-controller:certificates
+- - vault:certificates
+  - openstack-dashboard:certificates
+- - vault:certificates
+  - placement:certificates
+applications:
   ceph-mon:
     annotations:
       gui-x: '750'
       gui-y: '500'
-    charm: cs:ceph-mon-44
+    charm: cs:~openstack-charmers-next/ceph-mon
     num_units: 3
     options:
-      expected-osd-count: 3
-      monitor-count: 3
-      source: cloud:bionic-train
+      expected-osd-count: *expected-osd-count
+      monitor-count: *expected-mon-count
+      source: *openstack-origin
     to:
-    - lxd:1
-    - lxd:2
-    - lxd:3
+    - 'lxd:0'
+    - 'lxd:1'
+    - 'lxd:2'
   ceph-osd:
     annotations:
       gui-x: '1000'
       gui-y: '500'
-    charm: cs:ceph-osd-294
-    comment: SET osd-devices to match your environment
+    charm: cs:~openstack-charmers-next/ceph-osd
     num_units: 3
     options:
-      osd-devices: /dev/sdb /dev/vdb
-      source: cloud:bionic-train
+      osd-devices: *osd-devices
+      source: *openstack-origin
     to:
+    - '0'
     - '1'
     - '2'
-    - '3'
   ceph-radosgw:
     annotations:
       gui-x: '1000'
       gui-y: '250'
-    charm: cs:ceph-radosgw-283
+    charm: cs:~openstack-charmers-next/ceph-radosgw
     num_units: 1
     options:
-      source: cloud:bionic-train
+      source: *openstack-origin
     to:
-    - lxd:0
+    - 'lxd:0'
+  cinder-mysql-router:
+    charm: cs:~openstack-charmers-next/mysql-router
   cinder:
     annotations:
       gui-x: '750'
       gui-y: '0'
-    charm: cs:cinder-297
+    charm: cs:~openstack-charmers-next/cinder
     num_units: 1
     options:
       block-device: None
       glance-api-version: 2
-      openstack-origin: cloud:bionic-train
-      worker-multiplier: 0.25
+      worker-multiplier: *worker-multiplier
+      openstack-origin: *openstack-origin
     to:
-    - lxd:1
+    - 'lxd:1'
   cinder-ceph:
     annotations:
       gui-x: '750'
       gui-y: '250'
-    charm: cs:cinder-ceph-251
+    charm: cs:~openstack-charmers-next/cinder-ceph
     num_units: 0
+  glance-mysql-router:
+    charm: cs:~openstack-charmers-next/mysql-router
   glance:
     annotations:
       gui-x: '250'
       gui-y: '0'
-    charm: cs:glance-290
+    charm: cs:~openstack-charmers-next/glance
     num_units: 1
     options:
-      openstack-origin: cloud:bionic-train
-      worker-multiplier: 0.25
+      worker-multiplier: *worker-multiplier
+      openstack-origin: *openstack-origin
     to:
-    - lxd:2
+    - 'lxd:2'
+  keystone-mysql-router:
+    charm: cs:~openstack-charmers-next/mysql-router
   keystone:
     annotations:
       gui-x: '500'
       gui-y: '0'
-    charm: cs:keystone-309
+    charm: cs:~openstack-charmers-next/keystone
     num_units: 1
     options:
-      openstack-origin: cloud:bionic-train
-      worker-multiplier: 0.25
+      worker-multiplier: *worker-multiplier
+      openstack-origin: *openstack-origin
     to:
-    - lxd:3
-  mysql:
-    annotations:
-      gui-x: '0'
-      gui-y: '250'
-    charm: cs:percona-cluster-281
-    num_units: 1
-    options:
-      innodb-buffer-pool-size: 256M
-      max-connections: 1000
-      performance-schema: true
-    to:
-    - lxd:0
+    - 'lxd:0'
+  neutron-mysql-router:
+    charm: cs:~openstack-charmers-next/mysql-router
   neutron-api:
     annotations:
       gui-x: '500'
       gui-y: '500'
-    charm: cs:neutron-api-281
+    charm: cs:~openstack-charmers-next/neutron-api
     num_units: 1
     options:
-      flat-network-providers: physnet1
+      # NOTE(fnordahl): At current state of upstream Neutron development this
+      # is a requirement.  Remove once fixed upstream.
+      enable-ml2-port-security: true
       neutron-security-groups: true
-      openstack-origin: cloud:bionic-train
-      worker-multiplier: 0.25
+      flat-network-providers: physnet1
+      worker-multiplier: *worker-multiplier
+      openstack-origin: *openstack-origin
+      manage-neutron-plugin-legacy-mode: false
     to:
-    - lxd:1
-  neutron-gateway:
+    - 'lxd:1'
+  placement-mysql-router:
+    charm: cs:~openstack-charmers-next/mysql-router
+  placement:
     annotations:
       gui-x: '0'
-      gui-y: '0'
-    charm: cs:neutron-gateway-275
-    comment: SET data-port to match your environment
+      gui-y: '500'
+    charm: cs:~openstack-charmers-next/placement
     num_units: 1
     options:
-      bridge-mappings: physnet1:br-ex
-      data-port: br-ex:eno2
-      openstack-origin: cloud:bionic-train
-      worker-multiplier: 0.25
+      worker-multiplier: *worker-multiplier
+      openstack-origin: *openstack-origin
     to:
-    - '0'
-  neutron-openvswitch:
-    annotations:
-      gui-x: '250'
-      gui-y: '500'
-    charm: cs:neutron-openvswitch-269
-    num_units: 0
+    - 'lxd:2'
+  nova-mysql-router:
+    charm: cs:~openstack-charmers-next/mysql-router
   nova-cloud-controller:
     annotations:
       gui-x: '0'
       gui-y: '500'
-    charm: cs:nova-cloud-controller-338
+    charm: cs:~openstack-charmers-next/nova-cloud-controller
     num_units: 1
     options:
       network-manager: Neutron
-      openstack-origin: cloud:bionic-train
-      worker-multiplier: 0.25
+      worker-multiplier: *worker-multiplier
+      openstack-origin: *openstack-origin
     to:
-    - lxd:2
+    - 'lxd:0'
   nova-compute:
     annotations:
       gui-x: '250'
       gui-y: '250'
-    charm: cs:nova-compute-309
+    charm: cs:~openstack-charmers-next/nova-compute
     num_units: 3
     options:
       config-flags: default_ephemeral_format=ext4
       enable-live-migration: true
       enable-resize: true
       migration-auth-type: ssh
-      openstack-origin: cloud:bionic-train
+      openstack-origin: *openstack-origin
     to:
+    - '0'
     - '1'
     - '2'
-    - '3'
   ntp:
+    series: bionic
     annotations:
       gui-x: '1000'
       gui-y: '0'
-    charm: cs:ntp-35
+    charm: cs:ntp
     num_units: 0
+  dashboard-mysql-router:
+    charm: cs:~openstack-charmers-next/mysql-router
   openstack-dashboard:
     annotations:
       gui-x: '500'
       gui-y: '-250'
-    charm: cs:openstack-dashboard-295
+    charm: cs:~openstack-charmers-next/openstack-dashboard
     num_units: 1
     options:
-      openstack-origin: cloud:bionic-train
+      openstack-origin: *openstack-origin
     to:
-    - lxd:3
-  placement:
-    annotations:
-      gui-x: '0'
-      gui-y: '500'
-    charm: cs:~openstack-charmers/bionic/placement
-    num_units: 1
-    options:
-      openstack-origin: cloud:bionic-train
-      worker-multiplier: 0.25
-    to:
-    - lxd:2
+    - 'lxd:1'
   rabbitmq-server:
     annotations:
       gui-x: '500'
       gui-y: '250'
-    charm: cs:rabbitmq-server-97
+    charm: cs:~openstack-charmers-next/rabbitmq-server
     num_units: 1
     to:
-    - lxd:0
+    - 'lxd:2'
+  mysql-innodb-cluster:
+    charm: cs:~openstack-charmers-next/mysql-innodb-cluster
+    num_units: 3
+    to:
+    - 'lxd:0'
+    - 'lxd:1'
+    - 'lxd:2'
+  neutron-api-plugin-ovn:
+    charm: cs:~openstack-charmers-next/neutron-api-plugin-ovn
+  ovn-central:
+    charm: cs:~openstack-charmers-next/ovn-central
+    num_units: 3
+    options:
+      source: *openstack-origin
+    to:
+    - 'lxd:0'
+    - 'lxd:1'
+    - 'lxd:2'
+  ovn-chassis:
+    charm: cs:~openstack-charmers-next/ovn-chassis
+    comment: |
+      Please update the `bridge-interface-mappings` to values suitable for the
+      hardware used in your deployment.  See the referenced documentation at
+      the top of this file.
+    options:
+      ovn-bridge-mappings: physnet1:br-ex
+      bridge-interface-mappings: *data-port
+  vault-mysql-router:
+    charm: cs:~openstack-charmers-next/mysql-router
+  vault:
+    charm: cs:vault
+    num_units: 1
+    to:
+    - 'lxd:0'

--- a/stable/openstack-base/bundle.yaml
+++ b/stable/openstack-base/bundle.yaml
@@ -1,21 +1,214 @@
-# Open Virtual Network (OVN) - requires Train or later
-#
-# NOTE: Please review the value for the configuration option
-#       `bridge-interface-mappings` for the `ovn-chassis` charm.
-#       Refer to the [Open Virtual Network (OVN)](https://docs.openstack.org/project-deploy-guide/charm-deployment-guide/latest/app-ovn.html)
-#       section of the [OpenStack Charms Deployment Guide](https://docs.openstack.org/project-deploy-guide/charm-deployment-guide/latest/)
-#       for more information.
----
+applications:
+  ceph-mon:
+    annotations:
+      gui-x: '750'
+      gui-y: '500'
+    charm: cs:ceph-mon-48
+    num_units: 3
+    options:
+      expected-osd-count: 3
+      monitor-count: 3
+      source: distro-proposed
+    to:
+    - lxd:0
+    - lxd:1
+    - lxd:2
+  ceph-osd:
+    annotations:
+      gui-x: '1000'
+      gui-y: '500'
+    charm: cs:ceph-osd-303
+    num_units: 3
+    options:
+      osd-devices: /dev/sdb /dev/vdb
+      source: distro-proposed
+    to:
+    - '0'
+    - '1'
+    - '2'
+  ceph-radosgw:
+    annotations:
+      gui-x: '1000'
+      gui-y: '250'
+    charm: cs:ceph-radosgw-288
+    num_units: 1
+    options:
+      source: distro-proposed
+    to:
+    - lxd:0
+  cinder:
+    annotations:
+      gui-x: '750'
+      gui-y: '0'
+    charm: cs:cinder-303
+    num_units: 1
+    options:
+      block-device: None
+      glance-api-version: 2
+      openstack-origin: distro-proposed
+      worker-multiplier: 0.25
+    to:
+    - lxd:1
+  cinder-ceph:
+    annotations:
+      gui-x: '750'
+      gui-y: '250'
+    charm: cs:cinder-ceph-256
+    num_units: 0
+  cinder-mysql-router:
+    charm: cs:~openstack-charmers-next/mysql-router
+  dashboard-mysql-router:
+    charm: cs:~openstack-charmers-next/mysql-router
+  glance:
+    annotations:
+      gui-x: '250'
+      gui-y: '0'
+    charm: cs:glance-297
+    num_units: 1
+    options:
+      openstack-origin: distro-proposed
+      worker-multiplier: 0.25
+    to:
+    - lxd:2
+  glance-mysql-router:
+    charm: cs:~openstack-charmers-next/mysql-router
+  keystone:
+    annotations:
+      gui-x: '500'
+      gui-y: '0'
+    charm: cs:keystone-314
+    num_units: 1
+    options:
+      openstack-origin: distro-proposed
+      worker-multiplier: 0.25
+    to:
+    - lxd:0
+  keystone-mysql-router:
+    charm: cs:~openstack-charmers-next/mysql-router
+  mysql-innodb-cluster:
+    charm: cs:~openstack-charmers-next/mysql-innodb-cluster
+    num_units: 3
+    to:
+    - lxd:0
+    - lxd:1
+    - lxd:2
+  neutron-api:
+    annotations:
+      gui-x: '500'
+      gui-y: '500'
+    charm: cs:neutron-api-286
+    num_units: 1
+    options:
+      enable-ml2-port-security: true
+      flat-network-providers: physnet1
+      manage-neutron-plugin-legacy-mode: false
+      neutron-security-groups: true
+      openstack-origin: distro-proposed
+      worker-multiplier: 0.25
+    to:
+    - lxd:1
+  neutron-api-plugin-ovn:
+    charm: cs:~openstack-charmers-next/neutron-api-plugin-ovn
+  neutron-mysql-router:
+    charm: cs:~openstack-charmers-next/mysql-router
+  nova-cloud-controller:
+    annotations:
+      gui-x: '0'
+      gui-y: '500'
+    charm: cs:nova-cloud-controller-345
+    num_units: 1
+    options:
+      network-manager: Neutron
+      openstack-origin: distro-proposed
+      worker-multiplier: 0.25
+    to:
+    - lxd:0
+  nova-compute:
+    annotations:
+      gui-x: '250'
+      gui-y: '250'
+    charm: cs:nova-compute-316
+    num_units: 3
+    options:
+      config-flags: default_ephemeral_format=ext4
+      enable-live-migration: true
+      enable-resize: true
+      migration-auth-type: ssh
+      openstack-origin: distro-proposed
+    to:
+    - '0'
+    - '1'
+    - '2'
+  nova-mysql-router:
+    charm: cs:~openstack-charmers-next/mysql-router
+  ntp:
+    annotations:
+      gui-x: '1000'
+      gui-y: '0'
+    charm: cs:ntp-39
+    num_units: 0
+    series: bionic
+  openstack-dashboard:
+    annotations:
+      gui-x: '500'
+      gui-y: '-250'
+    charm: cs:openstack-dashboard-304
+    num_units: 1
+    options:
+      openstack-origin: distro-proposed
+    to:
+    - lxd:1
+  ovn-central:
+    charm: cs:~openstack-charmers-next/ovn-central
+    num_units: 3
+    options:
+      source: distro-proposed
+    to:
+    - lxd:0
+    - lxd:1
+    - lxd:2
+  ovn-chassis:
+    charm: cs:~openstack-charmers-next/ovn-chassis
+    comment: 'Please update the `bridge-interface-mappings` to values suitable for
+      the
+
+      hardware used in your deployment.  See the referenced documentation at
+
+      the top of this file.
+
+      '
+    options:
+      bridge-interface-mappings: br-ex:eno2
+      ovn-bridge-mappings: physnet1:br-ex
+  placement:
+    annotations:
+      gui-x: '0'
+      gui-y: '500'
+    charm: cs:~openstack-charmers-next/placement
+    num_units: 1
+    options:
+      openstack-origin: distro-proposed
+      worker-multiplier: 0.25
+    to:
+    - lxd:2
+  placement-mysql-router:
+    charm: cs:~openstack-charmers-next/mysql-router
+  rabbitmq-server:
+    annotations:
+      gui-x: '500'
+      gui-y: '250'
+    charm: cs:rabbitmq-server-102
+    num_units: 1
+    to:
+    - lxd:2
+  vault:
+    charm: cs:vault-39
+    num_units: 1
+    to:
+    - lxd:0
+  vault-mysql-router:
+    charm: cs:~openstack-charmers-next/mysql-router
 local_overlay_enabled: true
-series: focal
-# *** openstack-origin should be changed back to distro once this PPA is made redundant ***
-variables:
-  openstack-origin:    &openstack-origin     distro-proposed
-  data-port:           &data-port            br-ex:eno2
-  worker-multiplier:   &worker-multiplier    0.25
-  osd-devices:         &osd-devices          /dev/sdb /dev/vdb
-  expected-osd-count:  &expected-osd-count   3
-  expected-mon-count:  &expected-mon-count   3
 machines:
   '0':
     series: focal
@@ -138,211 +331,11 @@ relations:
   - openstack-dashboard:certificates
 - - vault:certificates
   - placement:certificates
-applications:
-  ceph-mon:
-    annotations:
-      gui-x: '750'
-      gui-y: '500'
-    charm: cs:~openstack-charmers-next/ceph-mon
-    num_units: 3
-    options:
-      expected-osd-count: *expected-osd-count
-      monitor-count: *expected-mon-count
-      source: *openstack-origin
-    to:
-    - 'lxd:0'
-    - 'lxd:1'
-    - 'lxd:2'
-  ceph-osd:
-    annotations:
-      gui-x: '1000'
-      gui-y: '500'
-    charm: cs:~openstack-charmers-next/ceph-osd
-    num_units: 3
-    options:
-      osd-devices: *osd-devices
-      source: *openstack-origin
-    to:
-    - '0'
-    - '1'
-    - '2'
-  ceph-radosgw:
-    annotations:
-      gui-x: '1000'
-      gui-y: '250'
-    charm: cs:~openstack-charmers-next/ceph-radosgw
-    num_units: 1
-    options:
-      source: *openstack-origin
-    to:
-    - 'lxd:0'
-  cinder-mysql-router:
-    charm: cs:~openstack-charmers-next/mysql-router
-  cinder:
-    annotations:
-      gui-x: '750'
-      gui-y: '0'
-    charm: cs:~openstack-charmers-next/cinder
-    num_units: 1
-    options:
-      block-device: None
-      glance-api-version: 2
-      worker-multiplier: *worker-multiplier
-      openstack-origin: *openstack-origin
-    to:
-    - 'lxd:1'
-  cinder-ceph:
-    annotations:
-      gui-x: '750'
-      gui-y: '250'
-    charm: cs:~openstack-charmers-next/cinder-ceph
-    num_units: 0
-  glance-mysql-router:
-    charm: cs:~openstack-charmers-next/mysql-router
-  glance:
-    annotations:
-      gui-x: '250'
-      gui-y: '0'
-    charm: cs:~openstack-charmers-next/glance
-    num_units: 1
-    options:
-      worker-multiplier: *worker-multiplier
-      openstack-origin: *openstack-origin
-    to:
-    - 'lxd:2'
-  keystone-mysql-router:
-    charm: cs:~openstack-charmers-next/mysql-router
-  keystone:
-    annotations:
-      gui-x: '500'
-      gui-y: '0'
-    charm: cs:~openstack-charmers-next/keystone
-    num_units: 1
-    options:
-      worker-multiplier: *worker-multiplier
-      openstack-origin: *openstack-origin
-    to:
-    - 'lxd:0'
-  neutron-mysql-router:
-    charm: cs:~openstack-charmers-next/mysql-router
-  neutron-api:
-    annotations:
-      gui-x: '500'
-      gui-y: '500'
-    charm: cs:~openstack-charmers-next/neutron-api
-    num_units: 1
-    options:
-      # NOTE(fnordahl): At current state of upstream Neutron development this
-      # is a requirement.  Remove once fixed upstream.
-      enable-ml2-port-security: true
-      neutron-security-groups: true
-      flat-network-providers: physnet1
-      worker-multiplier: *worker-multiplier
-      openstack-origin: *openstack-origin
-      manage-neutron-plugin-legacy-mode: false
-    to:
-    - 'lxd:1'
-  placement-mysql-router:
-    charm: cs:~openstack-charmers-next/mysql-router
-  placement:
-    annotations:
-      gui-x: '0'
-      gui-y: '500'
-    charm: cs:~openstack-charmers-next/placement
-    num_units: 1
-    options:
-      worker-multiplier: *worker-multiplier
-      openstack-origin: *openstack-origin
-    to:
-    - 'lxd:2'
-  nova-mysql-router:
-    charm: cs:~openstack-charmers-next/mysql-router
-  nova-cloud-controller:
-    annotations:
-      gui-x: '0'
-      gui-y: '500'
-    charm: cs:~openstack-charmers-next/nova-cloud-controller
-    num_units: 1
-    options:
-      network-manager: Neutron
-      worker-multiplier: *worker-multiplier
-      openstack-origin: *openstack-origin
-    to:
-    - 'lxd:0'
-  nova-compute:
-    annotations:
-      gui-x: '250'
-      gui-y: '250'
-    charm: cs:~openstack-charmers-next/nova-compute
-    num_units: 3
-    options:
-      config-flags: default_ephemeral_format=ext4
-      enable-live-migration: true
-      enable-resize: true
-      migration-auth-type: ssh
-      openstack-origin: *openstack-origin
-    to:
-    - '0'
-    - '1'
-    - '2'
-  ntp:
-    series: bionic
-    annotations:
-      gui-x: '1000'
-      gui-y: '0'
-    charm: cs:ntp
-    num_units: 0
-  dashboard-mysql-router:
-    charm: cs:~openstack-charmers-next/mysql-router
-  openstack-dashboard:
-    annotations:
-      gui-x: '500'
-      gui-y: '-250'
-    charm: cs:~openstack-charmers-next/openstack-dashboard
-    num_units: 1
-    options:
-      openstack-origin: *openstack-origin
-    to:
-    - 'lxd:1'
-  rabbitmq-server:
-    annotations:
-      gui-x: '500'
-      gui-y: '250'
-    charm: cs:~openstack-charmers-next/rabbitmq-server
-    num_units: 1
-    to:
-    - 'lxd:2'
-  mysql-innodb-cluster:
-    charm: cs:~openstack-charmers-next/mysql-innodb-cluster
-    num_units: 3
-    to:
-    - 'lxd:0'
-    - 'lxd:1'
-    - 'lxd:2'
-  neutron-api-plugin-ovn:
-    charm: cs:~openstack-charmers-next/neutron-api-plugin-ovn
-  ovn-central:
-    charm: cs:~openstack-charmers-next/ovn-central
-    num_units: 3
-    options:
-      source: *openstack-origin
-    to:
-    - 'lxd:0'
-    - 'lxd:1'
-    - 'lxd:2'
-  ovn-chassis:
-    charm: cs:~openstack-charmers-next/ovn-chassis
-    comment: |
-      Please update the `bridge-interface-mappings` to values suitable for the
-      hardware used in your deployment.  See the referenced documentation at
-      the top of this file.
-    options:
-      ovn-bridge-mappings: physnet1:br-ex
-      bridge-interface-mappings: *data-port
-  vault-mysql-router:
-    charm: cs:~openstack-charmers-next/mysql-router
-  vault:
-    charm: cs:~openstack-charmers-next/vault
-    num_units: 1
-    to:
-    - 'lxd:0'
+series: focal
+variables:
+  data-port: br-ex:eno2
+  expected-mon-count: 3
+  expected-osd-count: 3
+  openstack-origin: distro-proposed
+  osd-devices: /dev/sdb /dev/vdb
+  worker-multiplier: 0.25

--- a/stable/openstack-base/openrc
+++ b/stable/openstack-base/openrc
@@ -1,1 +1,1 @@
-openrcv3_project
+../shared/openrcv3_ssl_project

--- a/stable/openstack-base/openrcv3_domain
+++ b/stable/openstack-base/openrcv3_domain
@@ -1,1 +1,1 @@
-../shared/openrcv3_domain
+../shared/openrcv3_ssl_domain

--- a/stable/openstack-base/openrcv3_project
+++ b/stable/openstack-base/openrcv3_project
@@ -1,1 +1,1 @@
-../shared/openrcv3_project
+../shared/openrcv3_ssl_project

--- a/stable/openstack-base/openstack-base-spaces-overlay.yaml
+++ b/stable/openstack-base/openstack-base-spaces-overlay.yaml
@@ -1,1 +1,1 @@
-../overlays/openstack-base-spaces-overlay.yaml
+../../stable/overlays/openstack-base-spaces-overlay.yaml

--- a/stable/openstack-base/test-requirements.txt
+++ b/stable/openstack-base/test-requirements.txt
@@ -1,1 +1,3 @@
-../shared/test-requirements.txt
+# zaza
+git+https://github.com/openstack-charmers/zaza.git#egg=zaza;python_version>='3.0'
+git+https://github.com/openstack-charmers/zaza-openstack-tests.git#egg=zaza.openstack

--- a/stable/openstack-base/tests/bundles/overlays/bundle.yaml.j2
+++ b/stable/openstack-base/tests/bundles/overlays/bundle.yaml.j2
@@ -1,1 +1,0 @@
-../../../../overlays/openstack-base-virt-overlay.yaml

--- a/stable/openstack-base/tests/bundles/overlays/local-charm-overlay.yaml.j2
+++ b/stable/openstack-base/tests/bundles/overlays/local-charm-overlay.yaml.j2
@@ -1,0 +1,46 @@
+machines: {}
+applications:
+  ceph-osd:
+    to: []
+    storage:
+      osd-devices: 20GB
+  ceph-mon:
+    to: []
+  ceph-radosgw:
+    to: []
+  cinder:
+    expose: True
+    to: []
+  glance:
+    expose: True
+    to: []
+  keystone:
+    expose: True
+    to: []
+  mysql-innodb-cluster:
+    to: []
+  neutron-api:
+    expose: True
+    to: []
+  nova-cloud-controller:
+    expose: True
+    to: []
+  nova-compute:
+    constraints: mem=4G
+    annotations:
+    to: []
+  ntp:
+  openstack-dashboard:
+    expose: True
+    to: []
+  placement:
+    expose: True
+    to: []
+  ovn-central:
+    to: []
+  ovn-chassis:
+    to: []
+  rabbitmq-server:
+    to: []
+  vault:
+    to: []

--- a/stable/openstack-base/tests/tests.yaml
+++ b/stable/openstack-base/tests/tests.yaml
@@ -1,7 +1,35 @@
-configure: []
-dev_bundles: []
-gate_bundles:
-  -  bundle
-smoke_bundles: []
+configure:
+ - zaza.openstack.charm_tests.vault.setup.auto_initialize_no_validation
+ - zaza.openstack.charm_tests.keystone.setup.add_demo_user
+ - zaza.openstack.charm_tests.nova.setup.create_flavors
+ - zaza.openstack.charm_tests.nova.setup.manage_ssh_key
+ - zaza.openstack.charm_tests.neutron.setup.basic_overcloud_network
+ - zaza.openstack.charm_tests.glance.setup.add_lts_image
 tests:
-  - zaza.charm_tests.security.tests.FileOwnershipTest
+  - zaza.openstack.charm_tests.nova.tests.LTSGuestCreateTest
+target_deploy_status:
+  neutron-api-plugin-ovn:
+    workload-status: waiting
+    workload-status-message: "'ovsdb-cms' incomplete"
+  ovn-central:
+    workload-status: blocked
+    workload-status-message: "'certificates' missing"
+  ovn-chassis:
+    workload-status: blocked
+    workload-status-message: "'certificates' missing"
+  vault:
+    workload-status: blocked
+    workload-status-message: Vault needs to be initialized
+  vault:
+    workload-status: blocked
+    workload-status-message: Vault needs to be initialized
+  ntp:
+    workload-status: active
+    workload-status-message: "chrony: Ready"
+gate_bundles:
+  - bundle
+smoke_bundles:
+  - bundle
+tests_options:
+  force_deploy:
+    - bundle

--- a/stable/openstack-telemetry/README.md
+++ b/stable/openstack-telemetry/README.md
@@ -1,6 +1,6 @@
 # Basic OpenStack cloud
 
-The `openstack-base` bundle currently deploys a basic OpenStack cloud with
+The `openstack-telemetry` bundle currently deploys a basic OpenStack cloud with
 these foundational elements:
 
 - Ubuntu 20.04 LTS (Focal)
@@ -40,7 +40,7 @@ Servers should have two physical network ports cabled; the first is used for gen
 
 ## Components
 
- - 3 Nodes for Nova Compute and Ceph, with RabbitMQ, MySQL, Keystone, Glance, Neutron, OVN, Nova Cloud Controller, Ceph RADOS Gateway, Cinder and Horizon under LXC containers.
+ - 3 Nodes for Nova Compute and Ceph, with RabbitMQ, MySQL, Keystone, Glance, Neutron, OVN, Nova Cloud Controller, Ceph RADOS Gateway, Aodh, Gnocchi, Ceilometer, Memcached, Cinder and Horizon under LXC containers.
 
 All physical servers (not LXC containers) will also have NTP installed and configured to keep time in sync.
 
@@ -53,13 +53,13 @@ The Charm Tools allow you to download charms and bundles from the Charm Store.
 Install them now and then download the bundle:
 
     sudo snap install charm --classic
-    charm pull openstack-base ~/openstack-base
+    charm pull openstack-telemetry ~/openstack-telemetry
 
 ## Network spaces and overlays
 
 If the MAAS cluster contains network spaces you will need to bind them to the
 applications to be deployed. One way of doing this is with the
-`openstack-base-spaces-overlay.yaml` overlay bundle that ships with the bundle.
+`openstack-telemetry-spaces-overlay.yaml` overlay bundle that ships with the bundle.
 
 Like the main bundle file, it will likely require tailoring. The file employs
 the variable method of assigning values. The actual space name should be the
@@ -89,11 +89,11 @@ empty model 'default', change to that context:
 
 First move into the bundle directory:
 
-    cd ~/openstack-base
+    cd ~/openstack-telemetry
 
 To install OpenStack use this command if you're using the spaces overlay:
 
-    juju deploy ./bundle.yaml --overlay ./openstack-base-spaces-overlay.yaml
+    juju deploy ./bundle.yaml --overlay ./openstack-telemetry-spaces-overlay.yaml
 
 Otherwise, simply do:
 
@@ -117,7 +117,7 @@ can be finalised and the cloud used. See the following documentation for unlock 
 
 Confirm that you can access your cloud from the command line:
 
-    source ~/openstack-base/openrc
+    source ~/openstack-telemetry/openrc
     openstack service list
 
 You should get a listing of all registered cloud services.
@@ -263,7 +263,7 @@ Print the credentials in this way:
 
 If that does not work then source the `openrc` file and try again:
 
-    source ~/openstack-base/openrc
+    source ~/openstack-telemetry/openrc
 
 ## Scale the cloud
 
@@ -300,7 +300,7 @@ Configuring and managing services for an OpenStack cloud is complex. See the
 [hacluster-charm]: https://jaas.ai/hacluster
 [maas]: https://maas.io/
 [overlays]: https://github.com/openstack-charmers/openstack-bundles/tree/master/stable/overlays
-[spaces-overlay]: https://github.com/openstack-charmers/openstack-bundles/blob/master/stable/overlays/openstack-base-spaces-overlay.yaml
+[spaces-overlay]: https://github.com/openstack-charmers/openstack-bundles/blob/master/stable/overlays/openstack-telemetry-spaces-overlay.yaml
 [juju-and-maas]: https://jaas.ai/docs/maas-cloud
 [juju-constraints]: https://jaas.ai/docs/constraints#heading--setting-constraints-for-a-controller
 [juju-overlays]: https://jaas.ai/docs/charm-bundles#heading--overlay-bundles

--- a/stable/openstack-telemetry/README.md
+++ b/stable/openstack-telemetry/README.md
@@ -14,14 +14,6 @@ Certain configuration options within the bundle may need to be adjusted prior to
 
 For example, a section similar to this exists in the bundle.yaml file.  The third "column" are the values to set.  Some servers may not have eno2, they may have something like eth2 or some other network device name.  This needs to be adjusted prior to deployment.  The same principle holds for osd-devices.  The third column is a whitelist of devices to use for Ceph OSDs.  Adjust accordingly by editing bundle.yaml before deployment.
 
-```
-variables:
-  openstack-origin:    &openstack-origin     distro
-  data-port:           &data-port            br-ex:eno2
-  worker-multiplier:   &worker-multiplier    0.25
-  osd-devices:         &osd-devices          /dev/sdb /dev/vdb
-```
-
 Servers should have:
 
  - A minimum of 8GB of physical RAM.

--- a/stable/openstack-telemetry/README.md
+++ b/stable/openstack-telemetry/README.md
@@ -1,6 +1,6 @@
 # OpenStack Telemetry
 
-This example bundle extends the basic OpenStack Cloud bundle with Telemetry collection via Ceilometer.
+*DEV/TEST ONLY*: This unstable, development example bundle extends the basic OpenStack Cloud bundle with Telemetry collection via Ceilometer. See also: [Stable Bundles](https://jujucharms.com/u/openstack-charmers).
 
 Certain configuration options within the bundle may need to be adjusted prior to deployment to fit your particular set of hardware. For example, network device names and block device names can vary, and passwords should be yours.
 

--- a/stable/openstack-telemetry/README.md
+++ b/stable/openstack-telemetry/README.md
@@ -150,10 +150,13 @@ the bundle.
   system without first installing the ``python-keystoneclient`` and
   ``python-neutronclient`` deb packages.
 
+> **NOTE**: The network type required for OVN is geneve - the default for the
+  neutron-ext-net scripts is currently gre.
+
 For the "external" network a shared router ('provider-router') will be used by
 all tenants for public access to instances. The syntax is:
 
-    ./neutron-ext-net-ksv3 --network-type flat \
+    ./neutron-ext-net-ksv3 --network-type geneve \
         -g <gateway-ip> -c <network-cidr> \
         -f <pool-start>:<pool-end> <network-name>
 
@@ -162,7 +165,7 @@ the internet. Here, we'll configure for a private cloud. The actual values will
 depend on the environment that the second network interface (on all the nodes)
 is connected to. For example:
 
-    ./neutron-ext-net-ksv3 --network-type flat \
+    ./neutron-ext-net-ksv3 --network-type geneve \
         -g 10.230.168.1 -c 10.230.168.0/21 \
         -f 10.230.168.10:10.230.175.254 ext_net
 

--- a/stable/openstack-telemetry/README.md
+++ b/stable/openstack-telemetry/README.md
@@ -1,9 +1,313 @@
-# OpenStack Telemetry
+# Basic OpenStack cloud
 
-*DEV/TEST ONLY*: This unstable, development example bundle extends the basic OpenStack Cloud bundle with Telemetry collection via Ceilometer. See also: [Stable Bundles](https://jujucharms.com/u/openstack-charmers).
+The `openstack-base` bundle currently deploys a basic OpenStack cloud with
+these foundational elements:
+
+- Ubuntu 20.04 LTS (Focal)
+- OpenStack Ussuri
+- Ceph Octopus
+
+## Requirements
+This example bundle is designed to run on bare metal using Juju 2.x with [MAAS][] (Metal-as-a-Service); you will need to have setup a [MAAS][] deployment with a minimum of 4 physical servers prior to using this bundle.
 
 Certain configuration options within the bundle may need to be adjusted prior to deployment to fit your particular set of hardware. For example, network device names and block device names can vary, and passwords should be yours.
 
-For full details on the base cloud deployment please refer to the [Basic OpenStack Cloud][] bundle.
+For example, a section similar to this exists in the bundle.yaml file.  The third "column" are the values to set.  Some servers may not have eno2, they may have something like eth2 or some other network device name.  This needs to be adjusted prior to deployment.  The same principle holds for osd-devices.  The third column is a whitelist of devices to use for Ceph OSDs.  Adjust accordingly by editing bundle.yaml before deployment.
 
-[Basic OpenStack Cloud]: http://jujucharms.com/openstack-base
+```
+variables:
+  openstack-origin:    &openstack-origin     distro
+  data-port:           &data-port            br-ex:eno2
+  worker-multiplier:   &worker-multiplier    0.25
+  osd-devices:         &osd-devices          /dev/sdb /dev/vdb
+```
+
+Servers should have:
+
+ - A minimum of 8GB of physical RAM.
+ - Enough CPU cores to support your capacity requirements.
+ - Two disks (identified by /dev/sda and /dev/sdb); the first is used by MAAS for the OS install, the second for Ceph storage.
+ - Two cabled network ports on eno1 and eno2 (see below).
+
+Servers should have two physical network ports cabled; the first is used for general communication between services in the Cloud, the second is used for 'public' network traffic to and from instances (North/South traffic) running within the Cloud.
+
+
+> **Important**: The three MAAS nodes are needed for the actual OpenStack cloud;
+  they do not include the Juju controller. You actually need a minimum of four 
+  nodes. The controller node however can be a smaller system (1 CPU and 4 GiB
+  memory). Juju [constraints][juju-constraints] (e.g. 'tags') can be used to
+  target this smaller system at controller-creation time.
+
+## Components
+
+ - 3 Nodes for Nova Compute and Ceph, with RabbitMQ, MySQL, Keystone, Glance, Neutron, OVN, Nova Cloud Controller, Ceph RADOS Gateway, Cinder and Horizon under LXC containers.
+
+All physical servers (not LXC containers) will also have NTP installed and configured to keep time in sync.
+
+## Download the bundle
+
+Modifications will typically need to be made to this bundle for it to work in
+your environment. You will also require access to a credentials/init file.
+
+The Charm Tools allow you to download charms and bundles from the Charm Store.
+Install them now and then download the bundle:
+
+    sudo snap install charm --classic
+    charm pull openstack-base ~/openstack-base
+
+## Network spaces and overlays
+
+If the MAAS cluster contains network spaces you will need to bind them to the
+applications to be deployed. One way of doing this is with the
+`openstack-base-spaces-overlay.yaml` overlay bundle that ships with the bundle.
+
+Like the main bundle file, it will likely require tailoring. The file employs
+the variable method of assigning values. The actual space name should be the
+far-right value on this line:
+
+    variables:
+      public-space:        &public-space         public-space
+
+The [`openstack-bundles`][openstack-bundles] repository contains more example
+overlay bundles.
+
+See the Juju documentation on [network spaces][juju-spaces] and [overlay
+bundles][juju-overlays] for background information.
+
+## MAAS cloud and Juju controller
+
+Ensure that the MAAS cluster has been added to Juju as a cloud and that a Juju
+controller has been created for that cloud. See the Juju documentation for
+guidance: [Using MAAS with Juju][juju-and-maas].
+
+Assuming the controller is called 'maas-controller' and you want to use the
+empty model 'default', change to that context:
+
+    juju switch maas-controller:default
+
+## Deploy the cloud
+
+First move into the bundle directory:
+
+    cd ~/openstack-base
+
+To install OpenStack use this command if you're using the spaces overlay:
+
+    juju deploy ./bundle.yaml --overlay ./openstack-base-spaces-overlay.yaml
+
+Otherwise, simply do:
+
+    juju deploy ./bundle.yaml
+
+## Install the OpenStack clients
+
+You'll need the OpenStack clients in order to manage your cloud from the
+command line. Install them now:
+
+    sudo snap install openstackclients
+
+## Unlock vault
+
+This release uses vault to secure keystone - vault needs to be unlocked before the configuration
+can be finalised and the cloud used. See the following documentation for unlock steps:
+
+[Unlocking vault][vault appendix]
+
+## Access the cloud
+
+Confirm that you can access your cloud from the command line:
+
+    source ~/openstack-base/openrc
+    openstack service list
+
+You should get a listing of all registered cloud services.
+
+## Import an image
+
+You'll need to import a boot image in order to create instances. Here we
+import a Bionic amd64 image and call it 'bionic':
+
+    curl http://cloud-images.ubuntu.com/bionic/current/bionic-server-cloudimg-amd64.img | \
+        openstack image create --public --container-format=bare --disk-format=qcow2 \
+        bionic
+
+Images for other Ubuntu releases and architectures can be obtained in a similar
+way.
+
+For the ARM 64-bit (arm64) architecture you will need to configure the image to
+boot in UEFI mode:
+
+    curl http://cloud-images.ubuntu.com/bionic/current/bionic-server-cloudimg-arm64.img | \
+        openstack image create --public --container-format=bare --disk-format=qcow2 \
+        --property hw_firmware_type=uefi bionic
+
+## Configure networking
+
+Networking will be configured with the aid of two scripts supplied by
+the bundle.
+
+> **Note**: These scripts are written for Python 2 and may not work on a modern
+  system without first installing the ``python-keystoneclient`` and
+  ``python-neutronclient`` deb packages.
+
+For the "external" network a shared router ('provider-router') will be used by
+all tenants for public access to instances. The syntax is:
+
+    ./neutron-ext-net-ksv3 --network-type flat \
+        -g <gateway-ip> -c <network-cidr> \
+        -f <pool-start>:<pool-end> <network-name>
+
+In a public cloud the values would correspond to a publicly addressable part of
+the internet. Here, we'll configure for a private cloud. The actual values will
+depend on the environment that the second network interface (on all the nodes)
+is connected to. For example:
+
+    ./neutron-ext-net-ksv3 --network-type flat \
+        -g 10.230.168.1 -c 10.230.168.0/21 \
+        -f 10.230.168.10:10.230.175.254 ext_net
+
+For the "internal" tenant network, to which the instances are actually
+connected, the syntax is:
+
+    ./neutron-tenant-net-ksv3 -p <project> -r <router> \
+        [-N <dns-nameservers>] <network-name> <network-cidr>
+
+For example:
+
+    ./neutron-tenant-net-ksv3 -p admin -r provider-router internal 10.5.5.0/24
+
+See the [Neutron documentation][openstack-neutron] for more information.
+
+## Create a flavor
+
+Create at least one flavor to define a hardware profile for new instances. Here
+we create one called 'm1.tiny':
+
+    openstack flavor create --ram 1024 --disk 6 m1.tiny
+
+The above flavor is defined with minimum specifications. If you use larger
+values ensure that your compute nodes have the resources to accommodate them.
+
+## Import an SSH keypair
+
+An SSH keypair needs to be imported into the cloud in order to access your
+instances.
+
+Generate one first if you do not yet have one. This command creates a
+passphraseless keypair (remove the `-N` option to avoid that):
+
+    ssh-keygen -q -N '' -f ~/.ssh/id_mykey
+
+To import a keypair:
+
+    openstack keypair create --public-key ~/.ssh/id_mykey.pub mykey
+
+## Configure security groups
+
+To allow ICMP (ping) and SSH traffic to flow to cloud instances create
+corresponding rules for each security group:
+
+    for i in $(openstack security group list | awk '/default/{ print $2 }'); do
+        openstack security group rule create $i --protocol icmp --remote-ip 0.0.0.0/0;
+        openstack security group rule create $i --protocol tcp --remote-ip 0.0.0.0/0 --dst-port 22;
+	done
+
+You only need to perform this step once.
+
+## Create an instance
+
+To create a Bionic instance called 'bionic-1':
+
+    openstack server create --image bionic --flavor m1.tiny --key-name mykey \
+        --nic net-id=$(openstack network list | grep internal | awk '{ print $2 }') \
+        bionic-1
+
+## Attach a volume
+
+This step is optional.
+
+To create a 10GiB volume in Cinder and attach it to the new instance:
+
+    openstack volume create --size=10 <volume-name>
+    openstack server add volume bionic-1 <volume-name>
+
+The volume becomes immediately available to the instance. It will however need
+to be formatted and mounted before usage.
+
+## Assign a floating IP address
+
+To request and assign a floating IP address:
+
+    FLOATING_IP=$(openstack floating ip create -f value -c floating_ip_address ext_net)
+    openstack server add floating ip bionic-1 $FLOATING_IP
+
+## Log in to an instance
+
+To log in to the new instance:
+
+    ssh -i ~/.ssh/id_mykey ubuntu@$FLOATING_IP
+
+## Access the cloud dashboard
+
+The cloud dashboard (Horizon) can be accessed by going to:
+
+`http://<openstack-dashboard-ip>/horizon`
+
+The IP address is taken from the output to:
+
+    juju status openstack-dashboard
+
+Print the credentials in this way:
+
+    echo -e "Domain: $OS_USER_DOMAIN_NAME\nUser Name: $OS_USERNAME\nPassword: $OS_PASSWORD"
+
+If that does not work then source the `openrc` file and try again:
+
+    source ~/openstack-base/openrc
+
+## Scale the cloud
+
+The neutron-gateway, nova-compute, and ceph-osd applications are designed to be
+horizontally scalable.
+
+To scale nova-compute:
+
+    juju add-unit nova-compute # Add one more unit
+    juju add-unit -n5 nova-compute # Add 5 more units
+
+To scale ceph-osd:
+
+    juju add-unit ceph-osd # Add one more unit
+    juju add-unit -n50 ceph-osd # add 50 more units
+
+The ceph-osd application can also be scaled by placing units on the same
+machine where either the nova-compute units currently reside. This can be done
+via a "placement directive" (the `--to` option):
+
+    juju add-unit --to <machine-id> ceph-osd
+
+Other applications in this bundle can be used in conjunction with the
+[`hacluster`][hacluster-charm] subordinate charm to produce scalable, highly
+available cloud services.
+
+## Next steps
+
+Configuring and managing services for an OpenStack cloud is complex. See the
+[OpenStack Administrator Guides][openstack-admin-guides] for help.
+
+<!-- LINKS -->
+
+[hacluster-charm]: https://jaas.ai/hacluster
+[maas]: https://maas.io/
+[overlays]: https://github.com/openstack-charmers/openstack-bundles/tree/master/stable/overlays
+[spaces-overlay]: https://github.com/openstack-charmers/openstack-bundles/blob/master/stable/overlays/openstack-base-spaces-overlay.yaml
+[juju-and-maas]: https://jaas.ai/docs/maas-cloud
+[juju-constraints]: https://jaas.ai/docs/constraints#heading--setting-constraints-for-a-controller
+[juju-overlays]: https://jaas.ai/docs/charm-bundles#heading--overlay-bundles
+[juju-spaces]: https://jaas.ai/docs/spaces
+[openstack-neutron]: https://docs.openstack.org/neutron/
+[openstack-admin-guides]: http://docs.openstack.org/admin
+[openstack-bundles]: https://github.com/openstack-charmers/openstack-bundles/tree/master/stable/overlays
+[ubuntu-cloud-images]: http://cloud-images.ubuntu.com
+[Vault Unlock]: https://docs.openstack.org/project-deploy-guide/charm-deployment-guide/latest/app-vault.html
+

--- a/stable/openstack-telemetry/README.md
+++ b/stable/openstack-telemetry/README.md
@@ -106,12 +106,12 @@ command line. Install them now:
 
     sudo snap install openstackclients
 
-## Unlock vault
+## Unseal vault
 
-This release uses vault to secure keystone - vault needs to be unlocked before the configuration
-can be finalised and the cloud used. See the following documentation for unlock steps:
+This release uses vault to secure keystone - vault needs to be unsealed before the configuration
+can be finalised and the cloud used. See the following documentation for unseal steps:
 
-[Unlocking vault][vault appendix]
+[Unsealing vault][vault-appendix]
 
 ## Access the cloud
 

--- a/stable/openstack-telemetry/bundle.yaml
+++ b/stable/openstack-telemetry/bundle.yaml
@@ -402,7 +402,7 @@ applications:
   vault-mysql-router:
     charm: cs:~openstack-charmers-next/mysql-router
   vault:
-    charm: cs:vault
+    charm: cs:~openstack-charmers-next/vault
     num_units: 1
     to:
     - 'lxd:0'

--- a/stable/openstack-telemetry/bundle.yaml
+++ b/stable/openstack-telemetry/bundle.yaml
@@ -1,21 +1,263 @@
-# Open Virtual Network (OVN) - requires Train or later
-#
-# NOTE: Please review the value for the configuration option
-#       `bridge-interface-mappings` for the `ovn-chassis` charm.
-#       Refer to the [Open Virtual Network (OVN)](https://docs.openstack.org/project-deploy-guide/charm-deployment-guide/latest/app-ovn.html)
-#       section of the [OpenStack Charms Deployment Guide](https://docs.openstack.org/project-deploy-guide/charm-deployment-guide/latest/)
-#       for more information.
----
+applications:
+  aodh:
+    annotations:
+      gui-x: '1500'
+      gui-y: '0'
+    charm: cs:aodh-41
+    num_units: 1
+    options:
+      openstack-origin: distro-proposed
+    to:
+    - lxd:0
+  aodh-mysql-router:
+    charm: cs:~openstack-charmers-next/mysql-router
+  ceilometer:
+    annotations:
+      gui-x: '1250'
+      gui-y: '0'
+    charm: cs:ceilometer-273
+    num_units: 1
+    options:
+      openstack-origin: distro-proposed
+    to:
+    - lxd:2
+  ceilometer-agent:
+    annotations:
+      gui-x: '1250'
+      gui-y: '500'
+    charm: cs:ceilometer-agent-263
+    num_units: 0
+  ceph-mon:
+    annotations:
+      gui-x: '750'
+      gui-y: '500'
+    charm: cs:ceph-mon-48
+    num_units: 3
+    options:
+      expected-osd-count: 3
+      monitor-count: 3
+      source: distro-proposed
+    to:
+    - lxd:0
+    - lxd:1
+    - lxd:2
+  ceph-osd:
+    annotations:
+      gui-x: '1000'
+      gui-y: '500'
+    charm: cs:ceph-osd-303
+    num_units: 3
+    options:
+      osd-devices: /dev/sdb /dev/vdb
+      source: distro-proposed
+    to:
+    - '0'
+    - '1'
+    - '2'
+  ceph-radosgw:
+    annotations:
+      gui-x: '1000'
+      gui-y: '250'
+    charm: cs:ceph-radosgw-288
+    num_units: 1
+    options:
+      source: distro-proposed
+    to:
+    - lxd:0
+  cinder:
+    annotations:
+      gui-x: '750'
+      gui-y: '0'
+    charm: cs:cinder-303
+    num_units: 1
+    options:
+      block-device: None
+      glance-api-version: 2
+      openstack-origin: distro-proposed
+      worker-multiplier: 0.25
+    to:
+    - lxd:1
+  cinder-ceph:
+    annotations:
+      gui-x: '750'
+      gui-y: '250'
+    charm: cs:cinder-ceph-256
+    num_units: 0
+  cinder-mysql-router:
+    charm: cs:~openstack-charmers-next/mysql-router
+  dashboard-mysql-router:
+    charm: cs:~openstack-charmers-next/mysql-router
+  glance:
+    annotations:
+      gui-x: '250'
+      gui-y: '0'
+    charm: cs:glance-297
+    num_units: 1
+    options:
+      openstack-origin: distro-proposed
+      worker-multiplier: 0.25
+    to:
+    - lxd:2
+  glance-mysql-router:
+    charm: cs:~openstack-charmers-next/mysql-router
+  gnocchi:
+    annotations:
+      gui-x: '1500'
+      gui-y: '250'
+    charm: cs:gnocchi-39
+    num_units: 1
+    options:
+      openstack-origin: distro-proposed
+    to:
+    - lxd:1
+  gnocchi-mysql-router:
+    charm: cs:~openstack-charmers-next/mysql-router
+  keystone:
+    annotations:
+      gui-x: '500'
+      gui-y: '0'
+    charm: cs:keystone-314
+    num_units: 1
+    options:
+      openstack-origin: distro-proposed
+      worker-multiplier: 0.25
+    to:
+    - lxd:0
+  keystone-mysql-router:
+    charm: cs:~openstack-charmers-next/mysql-router
+  memcached:
+    annotations:
+      gui-x: '1500'
+      gui-y: '500'
+    charm: cs:memcached-28
+    num_units: 1
+    series: bionic
+    to:
+    - lxd:2
+  mysql-innodb-cluster:
+    charm: cs:~openstack-charmers-next/mysql-innodb-cluster
+    num_units: 3
+    to:
+    - lxd:0
+    - lxd:1
+    - lxd:2
+  neutron-api:
+    annotations:
+      gui-x: '500'
+      gui-y: '500'
+    charm: cs:neutron-api-286
+    num_units: 1
+    options:
+      enable-ml2-port-security: true
+      flat-network-providers: physnet1
+      manage-neutron-plugin-legacy-mode: false
+      neutron-security-groups: true
+      openstack-origin: distro-proposed
+      worker-multiplier: 0.25
+    to:
+    - lxd:1
+  neutron-api-plugin-ovn:
+    charm: cs:~openstack-charmers-next/neutron-api-plugin-ovn
+  neutron-mysql-router:
+    charm: cs:~openstack-charmers-next/mysql-router
+  nova-cloud-controller:
+    annotations:
+      gui-x: '0'
+      gui-y: '500'
+    charm: cs:nova-cloud-controller-345
+    num_units: 1
+    options:
+      network-manager: Neutron
+      openstack-origin: distro-proposed
+      worker-multiplier: 0.25
+    to:
+    - lxd:0
+  nova-compute:
+    annotations:
+      gui-x: '250'
+      gui-y: '250'
+    charm: cs:nova-compute-316
+    num_units: 3
+    options:
+      config-flags: default_ephemeral_format=ext4
+      enable-live-migration: true
+      enable-resize: true
+      migration-auth-type: ssh
+      openstack-origin: distro-proposed
+    to:
+    - '0'
+    - '1'
+    - '2'
+  nova-mysql-router:
+    charm: cs:~openstack-charmers-next/mysql-router
+  ntp:
+    annotations:
+      gui-x: '1000'
+      gui-y: '0'
+    charm: cs:ntp-39
+    num_units: 0
+    series: bionic
+  openstack-dashboard:
+    annotations:
+      gui-x: '500'
+      gui-y: '-250'
+    charm: cs:openstack-dashboard-304
+    num_units: 1
+    options:
+      openstack-origin: distro-proposed
+    to:
+    - lxd:1
+  ovn-central:
+    charm: cs:~openstack-charmers-next/ovn-central
+    num_units: 3
+    options:
+      source: distro-proposed
+    to:
+    - lxd:0
+    - lxd:1
+    - lxd:2
+  ovn-chassis:
+    charm: cs:~openstack-charmers-next/ovn-chassis
+    comment: 'Please update the `bridge-interface-mappings` to values suitable for
+      the
+
+      hardware used in your deployment.  See the referenced documentation at
+
+      the top of this file.
+
+      '
+    options:
+      bridge-interface-mappings: br-ex:eno2
+      ovn-bridge-mappings: physnet1:br-ex
+  placement:
+    annotations:
+      gui-x: '0'
+      gui-y: '500'
+    charm: cs:~openstack-charmers-next/placement
+    num_units: 1
+    options:
+      openstack-origin: distro-proposed
+      worker-multiplier: 0.25
+    to:
+    - lxd:2
+  placement-mysql-router:
+    charm: cs:~openstack-charmers-next/mysql-router
+  rabbitmq-server:
+    annotations:
+      gui-x: '500'
+      gui-y: '250'
+    charm: cs:rabbitmq-server-102
+    num_units: 1
+    to:
+    - lxd:2
+  vault:
+    charm: cs:vault-39
+    num_units: 1
+    to:
+    - lxd:0
+  vault-mysql-router:
+    charm: cs:~openstack-charmers-next/mysql-router
 local_overlay_enabled: true
-series: focal
-# *** openstack-origin should be changed back to distro once this PPA is made redundant ***
-variables:
-  openstack-origin:    &openstack-origin     distro-proposed
-  data-port:           &data-port            br-ex:eno2
-  worker-multiplier:   &worker-multiplier    0.25
-  osd-devices:         &osd-devices          /dev/sdb /dev/vdb
-  expected-osd-count:  &expected-osd-count   3
-  expected-mon-count:  &expected-mon-count   3
 machines:
   '0':
     series: focal
@@ -170,261 +412,11 @@ relations:
   - ceilometer:metric-service
 - - gnocchi:identity-service
   - keystone:identity-service
-applications:
-  aodh:
-    annotations:
-      gui-x: '1500'
-      gui-y: '0'
-    charm: cs:~openstack-charmers-next/aodh
-    num_units: 1
-    options:
-      openstack-origin: *openstack-origin
-    to:
-    - 'lxd:0'
-  aodh-mysql-router:
-    charm: cs:~openstack-charmers-next/mysql-router
-  ceilometer:
-    annotations:
-      gui-x: '1250'
-      gui-y: '0'
-    charm: cs:~openstack-charmers-next/ceilometer
-    num_units: 1
-    options:
-      openstack-origin: *openstack-origin
-    to:
-    - 'lxd:2'
-  ceilometer-agent:
-    annotations:
-      gui-x: '1250'
-      gui-y: '500'
-    charm: cs:~openstack-charmers-next/ceilometer-agent
-    num_units: 0
-  ceph-mon:
-    annotations:
-      gui-x: '750'
-      gui-y: '500'
-    charm: cs:~openstack-charmers-next/ceph-mon
-    num_units: 3
-    options:
-      expected-osd-count: *expected-osd-count
-      monitor-count: *expected-mon-count
-      source: *openstack-origin
-    to:
-    - 'lxd:0'
-    - 'lxd:1'
-    - 'lxd:2'
-  ceph-osd:
-    annotations:
-      gui-x: '1000'
-      gui-y: '500'
-    charm: cs:~openstack-charmers-next/ceph-osd
-    num_units: 3
-    options:
-      osd-devices: *osd-devices
-      source: *openstack-origin
-    to:
-    - '0'
-    - '1'
-    - '2'
-  ceph-radosgw:
-    annotations:
-      gui-x: '1000'
-      gui-y: '250'
-    charm: cs:~openstack-charmers-next/ceph-radosgw
-    num_units: 1
-    options:
-      source: *openstack-origin
-    to:
-    - 'lxd:0'
-  cinder-mysql-router:
-    charm: cs:~openstack-charmers-next/mysql-router
-  cinder:
-    annotations:
-      gui-x: '750'
-      gui-y: '0'
-    charm: cs:~openstack-charmers-next/cinder
-    num_units: 1
-    options:
-      block-device: None
-      glance-api-version: 2
-      worker-multiplier: *worker-multiplier
-      openstack-origin: *openstack-origin
-    to:
-    - 'lxd:1'
-  cinder-ceph:
-    annotations:
-      gui-x: '750'
-      gui-y: '250'
-    charm: cs:~openstack-charmers-next/cinder-ceph
-    num_units: 0
-  glance-mysql-router:
-    charm: cs:~openstack-charmers-next/mysql-router
-  glance:
-    annotations:
-      gui-x: '250'
-      gui-y: '0'
-    charm: cs:~openstack-charmers-next/glance
-    num_units: 1
-    options:
-      worker-multiplier: *worker-multiplier
-      openstack-origin: *openstack-origin
-    to:
-    - 'lxd:2'
-  keystone-mysql-router:
-    charm: cs:~openstack-charmers-next/mysql-router
-  keystone:
-    annotations:
-      gui-x: '500'
-      gui-y: '0'
-    charm: cs:~openstack-charmers-next/keystone
-    num_units: 1
-    options:
-      worker-multiplier: *worker-multiplier
-      openstack-origin: *openstack-origin
-    to:
-    - 'lxd:0'
-  neutron-mysql-router:
-    charm: cs:~openstack-charmers-next/mysql-router
-  neutron-api:
-    annotations:
-      gui-x: '500'
-      gui-y: '500'
-    charm: cs:~openstack-charmers-next/neutron-api
-    num_units: 1
-    options:
-      # NOTE(fnordahl): At current state of upstream Neutron development this
-      # is a requirement.  Remove once fixed upstream.
-      enable-ml2-port-security: true
-      neutron-security-groups: true
-      flat-network-providers: physnet1
-      worker-multiplier: *worker-multiplier
-      openstack-origin: *openstack-origin
-      manage-neutron-plugin-legacy-mode: false
-    to:
-    - 'lxd:1'
-  placement-mysql-router:
-    charm: cs:~openstack-charmers-next/mysql-router
-  placement:
-    annotations:
-      gui-x: '0'
-      gui-y: '500'
-    charm: cs:~openstack-charmers-next/placement
-    num_units: 1
-    options:
-      worker-multiplier: *worker-multiplier
-      openstack-origin: *openstack-origin
-    to:
-    - 'lxd:2'
-  nova-mysql-router:
-    charm: cs:~openstack-charmers-next/mysql-router
-  nova-cloud-controller:
-    annotations:
-      gui-x: '0'
-      gui-y: '500'
-    charm: cs:~openstack-charmers-next/nova-cloud-controller
-    num_units: 1
-    options:
-      network-manager: Neutron
-      worker-multiplier: *worker-multiplier
-      openstack-origin: *openstack-origin
-    to:
-    - 'lxd:0'
-  nova-compute:
-    annotations:
-      gui-x: '250'
-      gui-y: '250'
-    charm: cs:~openstack-charmers-next/nova-compute
-    num_units: 3
-    options:
-      config-flags: default_ephemeral_format=ext4
-      enable-live-migration: true
-      enable-resize: true
-      migration-auth-type: ssh
-      openstack-origin: *openstack-origin
-    to:
-    - '0'
-    - '1'
-    - '2'
-  ntp:
-    series: bionic
-    annotations:
-      gui-x: '1000'
-      gui-y: '0'
-    charm: cs:ntp
-    num_units: 0
-  dashboard-mysql-router:
-    charm: cs:~openstack-charmers-next/mysql-router
-  openstack-dashboard:
-    annotations:
-      gui-x: '500'
-      gui-y: '-250'
-    charm: cs:~openstack-charmers-next/openstack-dashboard
-    num_units: 1
-    options:
-      openstack-origin: *openstack-origin
-    to:
-    - 'lxd:1'
-  rabbitmq-server:
-    annotations:
-      gui-x: '500'
-      gui-y: '250'
-    charm: cs:~openstack-charmers-next/rabbitmq-server
-    num_units: 1
-    to:
-    - 'lxd:2'
-  mysql-innodb-cluster:
-    charm: cs:~openstack-charmers-next/mysql-innodb-cluster
-    num_units: 3
-    to:
-    - 'lxd:0'
-    - 'lxd:1'
-    - 'lxd:2'
-  neutron-api-plugin-ovn:
-    charm: cs:~openstack-charmers-next/neutron-api-plugin-ovn
-  ovn-central:
-    charm: cs:~openstack-charmers-next/ovn-central
-    num_units: 3
-    options:
-      source: *openstack-origin
-    to:
-    - 'lxd:0'
-    - 'lxd:1'
-    - 'lxd:2'
-  ovn-chassis:
-    charm: cs:~openstack-charmers-next/ovn-chassis
-    comment: |
-      Please update the `bridge-interface-mappings` to values suitable for the
-      hardware used in your deployment.  See the referenced documentation at
-      the top of this file.
-    options:
-      ovn-bridge-mappings: physnet1:br-ex
-      bridge-interface-mappings: *data-port
-  vault-mysql-router:
-    charm: cs:~openstack-charmers-next/mysql-router
-  vault:
-    charm: cs:~openstack-charmers-next/vault
-    num_units: 1
-    to:
-    - 'lxd:0'
-  gnocchi:
-    annotations:
-      gui-x: '1500'
-      gui-y: '250'
-    num_units: 1
-    charm: cs:~openstack-charmers-next/gnocchi
-    options:
-      openstack-origin: *openstack-origin
-    to:
-    - 'lxd:1'
-  gnocchi-mysql-router:
-    charm: cs:~openstack-charmers-next/mysql-router
-  memcached:
-    series: bionic
-    annotations:
-      gui-x: '1500'
-      gui-y: '500'
-    num_units: 1
-    charm: cs:memcached
-    to:
-    - 'lxd:2'
-
+series: focal
+variables:
+  data-port: br-ex:eno2
+  expected-mon-count: 3
+  expected-osd-count: 3
+  openstack-origin: distro-proposed
+  osd-devices: /dev/sdb /dev/vdb
+  worker-multiplier: 0.25

--- a/stable/openstack-telemetry/bundle.yaml
+++ b/stable/openstack-telemetry/bundle.yaml
@@ -1,35 +1,39 @@
+# Open Virtual Network (OVN) - requires Train or later
+#
+# NOTE: Please review the value for the configuration option
+#       `bridge-interface-mappings` for the `ovn-chassis` charm.
+#       Refer to the [Open Virtual Network (OVN)](https://docs.openstack.org/project-deploy-guide/charm-deployment-guide/latest/app-ovn.html)
+#       section of the [OpenStack Charms Deployment Guide](https://docs.openstack.org/project-deploy-guide/charm-deployment-guide/latest/)
+#       for more information.
+---
+local_overlay_enabled: true
+series: focal
+# *** openstack-origin should be changed back to distro once this PPA is made redundant ***
+variables:
+  openstack-origin:    &openstack-origin     distro-proposed
+  data-port:           &data-port            br-ex:eno2
+  worker-multiplier:   &worker-multiplier    0.25
+  osd-devices:         &osd-devices          /dev/sdb /dev/vdb
+  expected-osd-count:  &expected-osd-count   3
+  expected-mon-count:  &expected-mon-count   3
 machines:
   '0':
-    series: bionic
+    series: focal
   '1':
-    series: bionic
+    series: focal
   '2':
-    series: bionic
-  '3':
-    series: bionic
+    series: focal
 relations:
 - - nova-compute:amqp
   - rabbitmq-server:amqp
-- - neutron-gateway:amqp
-  - rabbitmq-server:amqp
-- - keystone:shared-db
-  - mysql:shared-db
 - - nova-cloud-controller:identity-service
   - keystone:identity-service
 - - glance:identity-service
   - keystone:identity-service
 - - neutron-api:identity-service
   - keystone:identity-service
-- - neutron-openvswitch:neutron-plugin-api
-  - neutron-api:neutron-plugin-api
-- - neutron-api:shared-db
-  - mysql:shared-db
 - - neutron-api:amqp
   - rabbitmq-server:amqp
-- - neutron-gateway:neutron-plugin-api
-  - neutron-api:neutron-plugin-api
-- - glance:shared-db
-  - mysql:shared-db
 - - glance:amqp
   - rabbitmq-server:amqp
 - - nova-cloud-controller:image-service
@@ -40,16 +44,8 @@ relations:
   - nova-compute:cloud-compute
 - - nova-cloud-controller:amqp
   - rabbitmq-server:amqp
-- - nova-cloud-controller:quantum-network-service
-  - neutron-gateway:quantum-network-service
-- - nova-compute:neutron-plugin
-  - neutron-openvswitch:neutron-plugin
-- - neutron-openvswitch:amqp
-  - rabbitmq-server:amqp
 - - openstack-dashboard:identity-service
   - keystone:identity-service
-- - nova-cloud-controller:shared-db
-  - mysql:shared-db
 - - nova-cloud-controller:neutron-api
   - neutron-api:neutron-api
 - - cinder:image-service
@@ -66,8 +62,6 @@ relations:
   - nova-compute:ceph
 - - nova-compute:ceph-access
   - cinder-ceph:ceph-access
-- - cinder:shared-db
-  - mysql:shared-db
 - - ceph-mon:client
   - cinder-ceph:ceph
 - - ceph-mon:client
@@ -76,12 +70,74 @@ relations:
   - ceph-mon:osd
 - - ntp:juju-info
   - nova-compute:juju-info
-- - ntp:juju-info
-  - neutron-gateway:juju-info
 - - ceph-radosgw:mon
   - ceph-mon:radosgw
 - - ceph-radosgw:identity-service
   - keystone:identity-service
+- - placement
+  - keystone
+- - placement
+  - nova-cloud-controller
+- - keystone:shared-db
+  - keystone-mysql-router:shared-db
+- - cinder:shared-db
+  - cinder-mysql-router:shared-db
+- - glance:shared-db
+  - glance-mysql-router:shared-db
+- - nova-cloud-controller:shared-db
+  - nova-mysql-router:shared-db
+- - neutron-api:shared-db
+  - neutron-mysql-router:shared-db
+- - openstack-dashboard:shared-db
+  - dashboard-mysql-router:shared-db
+- - placement:shared-db
+  - placement-mysql-router:shared-db
+- - vault:shared-db
+  - vault-mysql-router:shared-db
+- - keystone-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - cinder-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - nova-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - glance-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - neutron-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - dashboard-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - placement-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - vault-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - neutron-api-plugin-ovn:neutron-plugin
+  - neutron-api:neutron-plugin-api-subordinate
+- - ovn-central:certificates
+  - vault:certificates
+- - ovn-central:ovsdb-cms
+  - neutron-api-plugin-ovn:ovsdb-cms
+- - neutron-api:certificates
+  - vault:certificates
+- - ovn-chassis:nova-compute
+  - nova-compute:neutron-plugin
+- - ovn-chassis:certificates
+  - vault:certificates
+- - ovn-chassis:ovsdb
+  - ovn-central:ovsdb
+- - vault:certificates
+  - neutron-api-plugin-ovn:certificates
+- - vault:certificates
+  - cinder:certificates
+- - vault:certificates
+  - glance:certificates
+- - vault:certificates
+  - keystone:certificates
+- - vault:certificates
+  - nova-cloud-controller:certificates
+- - vault:certificates
+  - openstack-dashboard:certificates
+- - vault:certificates
+  - placement:certificates
 - - ceilometer:amqp
   - rabbitmq-server:amqp
 - - ceilometer-agent:ceilometer-service
@@ -92,16 +148,20 @@ relations:
   - nova-compute:nova-ceilometer
 - - ceilometer-agent:amqp
   - rabbitmq-server:amqp
+- - aodh-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
 - - aodh:shared-db
-  - mysql:shared-db
+  - aodh-mysql-router:shared-db
 - - aodh:identity-service
   - keystone:identity-service
 - - aodh:amqp
   - rabbitmq-server:amqp
 - - gnocchi:storage-ceph
   - ceph-mon:client
+- - gnocchi-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
 - - gnocchi:shared-db
-  - mysql:shared-db
+  - gnocchi-mysql-router:shared-db
 - - gnocchi:amqp
   - rabbitmq-server:amqp
 - - gnocchi:coordinator-memcached
@@ -110,245 +170,261 @@ relations:
   - ceilometer:metric-service
 - - gnocchi:identity-service
   - keystone:identity-service
-- - ceilometer:identity-credentials
-  - keystone:identity-credentials
-- - placement
-  - mysql
-- - placement
-  - keystone
-- - placement
-  - nova-cloud-controller
-series: bionic
-services:
+applications:
   aodh:
     annotations:
       gui-x: '1500'
       gui-y: '0'
-    charm: cs:aodh-35
+    charm: cs:~openstack-charmers-next/aodh
     num_units: 1
     options:
-      openstack-origin: cloud:bionic-train
+      openstack-origin: *openstack-origin
     to:
-    - lxd:0
+    - 'lxd:0'
+  aodh-mysql-router:
+    charm: cs:~openstack-charmers-next/mysql-router
   ceilometer:
     annotations:
       gui-x: '1250'
       gui-y: '0'
-    charm: cs:ceilometer-268
+    charm: cs:~openstack-charmers-next/ceilometer
     num_units: 1
     options:
-      openstack-origin: cloud:bionic-train
+      openstack-origin: *openstack-origin
     to:
-    - lxd:2
+    - 'lxd:2'
   ceilometer-agent:
     annotations:
       gui-x: '1250'
       gui-y: '500'
-    charm: cs:ceilometer-agent-258
+    charm: cs:~openstack-charmers-next/ceilometer-agent
     num_units: 0
   ceph-mon:
     annotations:
       gui-x: '750'
       gui-y: '500'
-    charm: cs:ceph-mon-44
+    charm: cs:~openstack-charmers-next/ceph-mon
     num_units: 3
     options:
-      expected-osd-count: 3
-      monitor-count: 3
-      source: cloud:bionic-train
+      expected-osd-count: *expected-osd-count
+      monitor-count: *expected-mon-count
+      source: *openstack-origin
     to:
-    - lxd:1
-    - lxd:2
-    - lxd:3
+    - 'lxd:0'
+    - 'lxd:1'
+    - 'lxd:2'
   ceph-osd:
     annotations:
       gui-x: '1000'
       gui-y: '500'
-    charm: cs:ceph-osd-294
-    comment: SET osd-devices to match your environment
+    charm: cs:~openstack-charmers-next/ceph-osd
     num_units: 3
     options:
-      osd-devices: /dev/sdb /dev/vdb
-      source: cloud:bionic-train
+      osd-devices: *osd-devices
+      source: *openstack-origin
     to:
+    - '0'
     - '1'
     - '2'
-    - '3'
   ceph-radosgw:
     annotations:
       gui-x: '1000'
       gui-y: '250'
-    charm: cs:ceph-radosgw-283
+    charm: cs:~openstack-charmers-next/ceph-radosgw
     num_units: 1
     options:
-      source: cloud:bionic-train
+      source: *openstack-origin
     to:
-    - lxd:0
+    - 'lxd:0'
+  cinder-mysql-router:
+    charm: cs:~openstack-charmers-next/mysql-router
   cinder:
     annotations:
       gui-x: '750'
       gui-y: '0'
-    charm: cs:cinder-297
+    charm: cs:~openstack-charmers-next/cinder
     num_units: 1
     options:
       block-device: None
       glance-api-version: 2
-      openstack-origin: cloud:bionic-train
-      worker-multiplier: 0.25
+      worker-multiplier: *worker-multiplier
+      openstack-origin: *openstack-origin
     to:
-    - lxd:1
+    - 'lxd:1'
   cinder-ceph:
     annotations:
       gui-x: '750'
       gui-y: '250'
-    charm: cs:cinder-ceph-251
+    charm: cs:~openstack-charmers-next/cinder-ceph
     num_units: 0
+  glance-mysql-router:
+    charm: cs:~openstack-charmers-next/mysql-router
   glance:
     annotations:
       gui-x: '250'
       gui-y: '0'
-    charm: cs:glance-290
+    charm: cs:~openstack-charmers-next/glance
     num_units: 1
     options:
-      openstack-origin: cloud:bionic-train
-      worker-multiplier: 0.25
+      worker-multiplier: *worker-multiplier
+      openstack-origin: *openstack-origin
     to:
-    - lxd:2
-  gnocchi:
-    annotations:
-      gui-x: '1500'
-      gui-y: '250'
-    charm: cs:gnocchi-28
-    num_units: 1
-    options:
-      openstack-origin: cloud:bionic-train
-    to:
-    - lxd:1
+    - 'lxd:2'
+  keystone-mysql-router:
+    charm: cs:~openstack-charmers-next/mysql-router
   keystone:
     annotations:
       gui-x: '500'
       gui-y: '0'
-    charm: cs:keystone-309
+    charm: cs:~openstack-charmers-next/keystone
     num_units: 1
     options:
-      openstack-origin: cloud:bionic-train
-      worker-multiplier: 0.25
+      worker-multiplier: *worker-multiplier
+      openstack-origin: *openstack-origin
     to:
-    - lxd:3
-  memcached:
-    annotations:
-      gui-x: '1500'
-      gui-y: '500'
-    charm: cs:memcached-26
-    num_units: 1
-    to:
-    - lxd:2
-  mysql:
-    annotations:
-      gui-x: '0'
-      gui-y: '250'
-    charm: cs:percona-cluster-281
-    num_units: 1
-    options:
-      innodb-buffer-pool-size: 256M
-      max-connections: 1000
-    to:
-    - lxd:0
+    - 'lxd:0'
+  neutron-mysql-router:
+    charm: cs:~openstack-charmers-next/mysql-router
   neutron-api:
     annotations:
       gui-x: '500'
       gui-y: '500'
-    charm: cs:neutron-api-281
+    charm: cs:~openstack-charmers-next/neutron-api
     num_units: 1
     options:
-      flat-network-providers: physnet1
+      # NOTE(fnordahl): At current state of upstream Neutron development this
+      # is a requirement.  Remove once fixed upstream.
+      enable-ml2-port-security: true
       neutron-security-groups: true
-      openstack-origin: cloud:bionic-train
-      worker-multiplier: 0.25
+      flat-network-providers: physnet1
+      worker-multiplier: *worker-multiplier
+      openstack-origin: *openstack-origin
+      manage-neutron-plugin-legacy-mode: false
     to:
-    - lxd:1
-  neutron-gateway:
+    - 'lxd:1'
+  placement-mysql-router:
+    charm: cs:~openstack-charmers-next/mysql-router
+  placement:
     annotations:
       gui-x: '0'
-      gui-y: '0'
-    charm: cs:neutron-gateway-275
-    comment: SET data-port to match your environment
+      gui-y: '500'
+    charm: cs:~openstack-charmers-next/placement
     num_units: 1
     options:
-      bridge-mappings: physnet1:br-ex
-      data-port: br-ex:eno2
-      openstack-origin: cloud:bionic-train
-      worker-multiplier: 0.25
+      worker-multiplier: *worker-multiplier
+      openstack-origin: *openstack-origin
     to:
-    - '0'
-  neutron-openvswitch:
-    annotations:
-      gui-x: '250'
-      gui-y: '500'
-    charm: cs:neutron-openvswitch-269
-    num_units: 0
+    - 'lxd:2'
+  nova-mysql-router:
+    charm: cs:~openstack-charmers-next/mysql-router
   nova-cloud-controller:
     annotations:
       gui-x: '0'
       gui-y: '500'
-    charm: cs:nova-cloud-controller-338
+    charm: cs:~openstack-charmers-next/nova-cloud-controller
     num_units: 1
     options:
       network-manager: Neutron
-      openstack-origin: cloud:bionic-train
-      worker-multiplier: 0.25
+      worker-multiplier: *worker-multiplier
+      openstack-origin: *openstack-origin
     to:
-    - lxd:2
+    - 'lxd:0'
   nova-compute:
     annotations:
       gui-x: '250'
       gui-y: '250'
-    charm: cs:nova-compute-309
+    charm: cs:~openstack-charmers-next/nova-compute
     num_units: 3
     options:
       config-flags: default_ephemeral_format=ext4
       enable-live-migration: true
       enable-resize: true
       migration-auth-type: ssh
-      openstack-origin: cloud:bionic-train
+      openstack-origin: *openstack-origin
     to:
+    - '0'
     - '1'
     - '2'
-    - '3'
   ntp:
+    series: bionic
     annotations:
       gui-x: '1000'
       gui-y: '0'
-    charm: cs:ntp-35
+    charm: cs:ntp
     num_units: 0
+  dashboard-mysql-router:
+    charm: cs:~openstack-charmers-next/mysql-router
   openstack-dashboard:
     annotations:
       gui-x: '500'
       gui-y: '-250'
-    charm: cs:openstack-dashboard-295
+    charm: cs:~openstack-charmers-next/openstack-dashboard
     num_units: 1
     options:
-      openstack-origin: cloud:bionic-train
+      openstack-origin: *openstack-origin
     to:
-    - lxd:3
-  placement:
-    annotations:
-      gui-x: '0'
-      gui-y: '500'
-    charm: cs:~openstack-charmers/bionic/placement
-    num_units: 1
-    options:
-      openstack-origin: cloud:bionic-train
-      worker-multiplier: 0.25
-    to:
-    - lxd:2
+    - 'lxd:1'
   rabbitmq-server:
     annotations:
       gui-x: '500'
       gui-y: '250'
-    charm: cs:rabbitmq-server-97
+    charm: cs:~openstack-charmers-next/rabbitmq-server
     num_units: 1
-    options:
-      source: cloud:bionic-train
     to:
-    - lxd:0
+    - 'lxd:2'
+  mysql-innodb-cluster:
+    charm: cs:~openstack-charmers-next/mysql-innodb-cluster
+    num_units: 3
+    to:
+    - 'lxd:0'
+    - 'lxd:1'
+    - 'lxd:2'
+  neutron-api-plugin-ovn:
+    charm: cs:~openstack-charmers-next/neutron-api-plugin-ovn
+  ovn-central:
+    charm: cs:~openstack-charmers-next/ovn-central
+    num_units: 3
+    options:
+      source: *openstack-origin
+    to:
+    - 'lxd:0'
+    - 'lxd:1'
+    - 'lxd:2'
+  ovn-chassis:
+    charm: cs:~openstack-charmers-next/ovn-chassis
+    comment: |
+      Please update the `bridge-interface-mappings` to values suitable for the
+      hardware used in your deployment.  See the referenced documentation at
+      the top of this file.
+    options:
+      ovn-bridge-mappings: physnet1:br-ex
+      bridge-interface-mappings: *data-port
+  vault-mysql-router:
+    charm: cs:~openstack-charmers-next/mysql-router
+  vault:
+    charm: cs:vault
+    num_units: 1
+    to:
+    - 'lxd:0'
+  gnocchi:
+    annotations:
+      gui-x: '1500'
+      gui-y: '250'
+    num_units: 1
+    charm: cs:~openstack-charmers-next/gnocchi
+    options:
+      openstack-origin: *openstack-origin
+    to:
+    - 'lxd:1'
+  gnocchi-mysql-router:
+    charm: cs:~openstack-charmers-next/mysql-router
+  memcached:
+    series: bionic
+    annotations:
+      gui-x: '1500'
+      gui-y: '500'
+    num_units: 1
+    charm: cs:memcached
+    to:
+    - 'lxd:2'
+

--- a/stable/openstack-telemetry/openrc
+++ b/stable/openstack-telemetry/openrc
@@ -1,1 +1,1 @@
-openrcv3_project
+../shared/openrcv3_ssl_project

--- a/stable/openstack-telemetry/openrcv3_domain
+++ b/stable/openstack-telemetry/openrcv3_domain
@@ -1,1 +1,1 @@
-../shared/openrcv3_domain
+../shared/openrcv3_ssl_domain

--- a/stable/openstack-telemetry/openrcv3_project
+++ b/stable/openstack-telemetry/openrcv3_project
@@ -1,1 +1,1 @@
-../shared/openrcv3_project
+../shared/openrcv3_ssl_project

--- a/stable/openstack-telemetry/openstack-telemetry-spaces-overlay.yaml
+++ b/stable/openstack-telemetry/openstack-telemetry-spaces-overlay.yaml
@@ -1,1 +1,0 @@
-../overlays/openstack-telemetry-spaces-overlay.yaml

--- a/stable/openstack-telemetry/tests/bundles/bundle.yaml
+++ b/stable/openstack-telemetry/tests/bundles/bundle.yaml
@@ -1,0 +1,1 @@
+../../bundle.yaml

--- a/stable/openstack-telemetry/tests/bundles/overlays/local-charm-overlay.yaml.j2
+++ b/stable/openstack-telemetry/tests/bundles/overlays/local-charm-overlay.yaml.j2
@@ -1,0 +1,46 @@
+machines: {}
+applications:
+  ceph-osd:
+    to: []
+    storage:
+      osd-devices: 20GB
+  ceph-mon:
+    to: []
+  ceph-radosgw:
+    to: []
+  cinder:
+    expose: True
+    to: []
+  glance:
+    expose: True
+    to: []
+  keystone:
+    expose: True
+    to: []
+  mysql-innodb-cluster:
+    to: []
+  neutron-api:
+    expose: True
+    to: []
+  nova-cloud-controller:
+    expose: True
+    to: []
+  nova-compute:
+    constraints: mem=4G
+    annotations:
+    to: []
+  ntp:
+  openstack-dashboard:
+    expose: True
+    to: []
+  placement:
+    expose: True
+    to: []
+  ovn-central:
+    to: []
+  ovn-chassis:
+    to: []
+  rabbitmq-server:
+    to: []
+  vault:
+    to: []

--- a/stable/openstack-telemetry/tests/tests.yaml
+++ b/stable/openstack-telemetry/tests/tests.yaml
@@ -1,0 +1,35 @@
+configure:
+ - zaza.openstack.charm_tests.vault.setup.auto_initialize_no_validation
+ - zaza.openstack.charm_tests.keystone.setup.add_demo_user
+ - zaza.openstack.charm_tests.nova.setup.create_flavors
+ - zaza.openstack.charm_tests.nova.setup.manage_ssh_key
+ - zaza.openstack.charm_tests.neutron.setup.basic_overcloud_network
+ - zaza.openstack.charm_tests.glance.setup.add_lts_image
+tests:
+  - zaza.openstack.charm_tests.nova.tests.LTSGuestCreateTest
+target_deploy_status:
+  neutron-api-plugin-ovn:
+    workload-status: waiting
+    workload-status-message: "'ovsdb-cms' incomplete"
+  ovn-central:
+    workload-status: blocked
+    workload-status-message: "'certificates' missing"
+  ovn-chassis:
+    workload-status: blocked
+    workload-status-message: "'certificates' missing"
+  vault:
+    workload-status: blocked
+    workload-status-message: Vault needs to be initialized
+  vault:
+    workload-status: blocked
+    workload-status-message: Vault needs to be initialized
+  ntp:
+    workload-status: active
+    workload-status-message: "chrony: Ready"
+gate_bundles:
+  - bundle
+smoke_bundles:
+  - bundle
+tests_options:
+  force_deploy:
+    - bundle

--- a/stable/shared/openrcv3_ssl_domain
+++ b/stable/shared/openrcv3_ssl_domain
@@ -1,0 +1,26 @@
+_OS_PARAMS=$(env | awk 'BEGIN {FS="="} /^OS_/ {print $1;}' | paste -sd ' ')
+for param in $_OS_PARAMS; do
+    if [ "$param" = "OS_AUTH_PROTOCOL" ]; then continue; fi
+    if [ "$param" = "OS_CACERT" ]; then continue; fi
+    unset $param
+done
+unset _OS_PARAMS
+
+_keystone_ip=$(juju run $_juju_model_arg --unit keystone/leader 'unit-get private-address')
+_password=$(juju run $_juju_model_arg --unit keystone/leader 'leader-get admin_passwd')
+juju run $_juju_model_arg --unit vault/leader 'leader-get root-ca' > /tmp/root-ca.crt
+_root_ca=/tmp/root-ca.crt
+
+export OS_AUTH_PROTOCOL=https
+export OS_CACERT=${_root_ca}
+export OS_AUTH_URL=${OS_AUTH_PROTOCOL:-http}://${_keystone_ip}:5000/v3
+export OS_USERNAME=admin
+export OS_PASSWORD=${_password}
+export OS_REGION_NAME=RegionOne
+export OS_DOMAIN_NAME=admin_domain
+export OS_USER_DOMAIN_NAME=admin_domain
+export OS_IDENTITY_API_VERSION=3
+# Swift needs this:
+export OS_AUTH_VERSION=3
+# Gnocchi needs this:
+export OS_AUTH_TYPE=password

--- a/stable/shared/openrcv3_ssl_project
+++ b/stable/shared/openrcv3_ssl_project
@@ -1,0 +1,27 @@
+_OS_PARAMS=$(env | awk 'BEGIN {FS="="} /^OS_/ {print $1;}' | paste -sd ' ')
+for param in $_OS_PARAMS; do
+    if [ "$param" = "OS_AUTH_PROTOCOL" ]; then continue; fi
+    if [ "$param" = "OS_CACERT" ]; then continue; fi
+    unset $param
+done
+unset _OS_PARAMS
+
+_keystone_ip=$(juju run $_juju_model_arg --unit keystone/leader 'unit-get private-address')
+_password=$(juju run $_juju_model_arg --unit keystone/leader 'leader-get admin_passwd')
+juju run $_juju_model_arg --unit vault/leader 'leader-get root-ca' > /tmp/root-ca.crt
+_root_ca=/tmp/root-ca.crt
+
+export OS_AUTH_PROTOCOL=https
+export OS_CACERT=${_root_ca}
+export OS_AUTH_URL=${OS_AUTH_PROTOCOL:-http}://${_keystone_ip}:5000/v3
+export OS_USERNAME=admin
+export OS_PASSWORD=${_password}
+export OS_USER_DOMAIN_NAME=admin_domain
+export OS_PROJECT_DOMAIN_NAME=admin_domain
+export OS_PROJECT_NAME=admin
+export OS_REGION_NAME=RegionOne
+export OS_IDENTITY_API_VERSION=3
+# Swift needs this:
+export OS_AUTH_VERSION=3
+# Gnocchi needs this
+export OS_AUTH_TYPE=password

--- a/stable/shared/test-requirements.txt
+++ b/stable/shared/test-requirements.txt
@@ -1,2 +1,4 @@
 # zaza
 git+https://github.com/openstack-charmers/zaza.git#egg=zaza
+# zaza.openstack
+git+https://github.com/openstack-charmers/zaza-openstack-tests.git#egg=zaza.openstack

--- a/tools/update-bundle-versions
+++ b/tools/update-bundle-versions
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import optparse
 import yaml
@@ -31,8 +31,8 @@ if __name__ == "__main__":
 
     http = urllib3.PoolManager()
 
-    for service in data['services']:
-        charm = data['services'][service]['charm']
+    for service in data['applications']:
+        charm = data['applications'][service]['charm']
         # Remove any version
         charm = charm.rstrip('-0123456789')
         charm = charm.split('/')[-1]
@@ -42,7 +42,7 @@ if __name__ == "__main__":
         revision = http.request('GET', url)
         if revision.status == 200:
            revision = yaml.load(revision.data)['Revision']
-           data['services'][service]['charm'] = "cs:{}-{}".format(charm, revision)
+           data['applications'][service]['charm'] = "cs:{}-{}".format(charm, revision)
     if opts.in_place:
         with open(bundle, 'w') as bundle_file:
             bundle_file.write(yaml.dump(data, default_flow_style=False))

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ envlist = lint
 skipsdist = True
 
 [testenv]
-basepython = python2.7
+basepython = python3
 setenv = VIRTUAL_ENV={envdir}
          PYTHONHASHSEED=0
 install_command =
@@ -13,10 +13,8 @@ passenv = TERM HOME
 whitelist_externals = bash
 
 [testenv:lint]
-commands = flake8 -v stable/shared/neutron* development/shared/neutron*
+commands = flake8 -v stable/shared/neutron-ext-net stable/shared/neutron-tenant-net development/shared/neutron-ext-net development/shared/neutron-tenant-net
            bash -ex tools/validate_bundles_yaml_load.sh
-           bash -ex tools/validate_bundles.sh
-#           bash -ex tools/validate_bundles_diff.sh  # Test has been broken in master for some time, and needs to be rewritten.
            bash -ex tools/validate_tools.sh
 
 [testenv:lint-light]
@@ -24,7 +22,6 @@ commands = flake8 -v stable/shared/neutron* development/shared/neutron*
 #   https://bugs.launchpad.net/juju-deployer/+bug/1678297
 commands = flake8 -v stable/shared/neutron-ext-net stable/shared/neutron-tenant-net development/shared/neutron-ext-net development/shared/neutron-tenant-net
            bash -ex tools/validate_bundles_yaml_load.sh
-#           bash -ex tools/validate_bundles_diff.sh  # Test has been broken in master for some time, and needs to be re-written.
            bash -ex tools/validate_tools.sh
 
 [testenv:sync-tools]


### PR DESCRIPTION
- Copy development/ceph-base-focal-octopus/bundle.yaml to stable/ceph-base
- Copy development/openstack-base-focal-ovn/* to stable/openstack-base-focal-ovn/*
- Copy development/openstack-telemetry-focal-ovn/* to stable/openstack-telemetry-focal-ovn/*
- Update stable/shared from development/shared
- Updated stable base and telemetry README.mmd
- Change default external network type to geneve from gre for OVN
- Fix tox and travis for py3 and Ubuntu 20.04
- Update bundles with stable charm revs