### PR TITLE
Update post deploy network configuration instructions

### DIFF
--- a/development/openstack-base-bionic-ussuri-ovn/README.md
+++ b/development/openstack-base-bionic-ussuri-ovn/README.md
@@ -12,7 +12,7 @@ For example, a section similar to this exists in the bundle.yaml file.  The thir
 
 ```
 variables:
-  openstack-origin:    &openstack-origin     cloud:eoan-train
+  openstack-origin:    &openstack-origin     cloud:bionic-ussuri
   data-port:           &data-port            br-ex:eno2
   worker-multiplier:   &worker-multiplier    0.25
   osd-devices:         &osd-devices          /dev/sdb /dev/vdb
@@ -94,36 +94,52 @@ You should get a full listing of all services registered in the cloud which shou
 
 In order to run instances on your cloud, you'll need to upload an image to boot instances:
 
-    curl http://cloud-images.ubuntu.com/eoan/current/eoan-server-cloudimg-amd64.img | \
-        openstack image create --public --container-format=bare --disk-format=qcow2 eoan
+    curl https://cloud-images.ubuntu.com/bionic/current/bionic-server-cloudimg-amd64.img | \
+        openstack image create --public --container-format=bare \
+            --disk-format=qcow2 bionic
 
 Images for other architectures can be obtained from [Ubuntu Cloud Images][].  Be sure to use the appropriate image for the cpu architecture.
 
 **Note:** for ARM 64-bit (arm64) guests, you will also need to configure the image to boot in UEFI mode:
 
-    curl http://cloud-images.ubuntu.com/eoan/current/eoan-server-cloudimg-arm64.img | \
-        openstack image create --public --container-format=bare --disk-format=qcow2 --property hw_firmware_type=uefi eoan
+    curl http://cloud-images.ubuntu.com/bionic/current/bionic-server-cloudimg-arm64.img | \
+        openstack image create --public --container-format=bare \
+            --disk-format=qcow2 --property hw_firmware_type=uefi bionic
 
 ### Configure networking
 
-For the purposes of a quick test, we'll setup an 'external' network and shared router ('provider-router') which will be used by all tenants for public access to instances:
-
-    ./neutron-ext-net-ksv3 --network-type flat \
-        -g <gateway-ip> -c <network-cidr> \
-        -f <pool-start>:<pool-end> ext_net
+For the purposes of a quick test, we'll setup an 'external' network and shared
+router ('provider-router') which will be used by all tenants for public access
+to instances:
 
 for example (for a private cloud):
 
-    ./neutron-ext-net-ksv3 --network-type flat \
-        -g 10.230.168.1 -c 10.230.168.0/21 \
-        -f 10.230.168.10:10.230.175.254 ext_net
+    openstack network create --external --provider-network-type flat \
+        --provider-physical-network physnet1 ext_net
 
-You'll need to adapt the parameters for the network configuration that eno2 on all the servers is connected to; in a public cloud deployment these ports would be connected to a publicly addressable part of the Internet.
+    openstack subnet create --subnet-range 192.0.2.0/24 --no-dhcp \
+        --gateway 192.0.2.1 --network ext_net \
+        --allocation-pool start=192.0.2.10,end=192.0.2.254 ext
 
-We'll also need an 'internal' network for the admin user which instances are actually connected to:
+You'll need to adapt the parameters for the network configuration that eno2 on
+all the servers is connected to; in a public cloud deployment these ports would
+be connected to a publicly addressable part of the Internet.
 
-    ./neutron-tenant-net-ksv3 -p admin -r provider-router \
-        [-N <dns-server>] internal 10.5.5.0/24
+We'll also need an 'internal' network for the admin user which instances are
+actually connected to:
+
+    openstack network create internal
+
+    openstack subnet create --network internal \
+        --subnet-range 198.51.100.0/24 \
+        --dns-nameserver 8.8.8.8 \
+        internal_subnet
+
+    openstack router create provider-router
+
+    openstack router set --external-gateway ext_net provider-router
+
+    openstack router add subnet provider-router internal_subnet
 
 Neutron provides a wide range of configuration options; see the [OpenStack Neutron][] documentation for more details.
 
@@ -148,9 +164,8 @@ First generate a SSH keypair so that you can access your instances once you've b
 
 You can now boot an instance on your cloud:
 
-    openstack server create --image eoan --flavor m1.small --key-name mykey \
-        --nic net-id=$(openstack network list | grep internal | awk '{ print $2 }') \
-        eoan-test
+    openstack server create --image bionic --flavor m1.small --key-name mykey \
+        --network internal bionic-test
 
 ### Attaching a volume
 
@@ -160,33 +175,42 @@ First, create a 10G volume in cinder:
 
 then attach it to the instance we just booted:
 
-    openstack server add volume eoan-test <name-of-volume>
+    openstack server add volume bionic-test <name-of-volume>
 
 The attached volume will be accessible once you login to the instance (see below).  It will need to be formatted and mounted!
 
 ### Accessing your instance
 
-In order to access the instance you just booted on the cloud, you'll need to assign a floating IP address to the instance:
+In order to access the instance you just booted on the cloud, you'll need to
+assign a floating IP address to the instance:
 
-    openstack floating ip create ext_net
-    openstack server add floating ip eoan-test <new-floating-ip>
+    FIP=$(openstack floating ip create -f value -c floating_ip_address ext_net)
+    openstack server add floating ip bionic-test $FIP
 
-and then allow access via SSH (and ping) - you only need to do these steps once:
+and then allow access via SSH (and ping) - you only need to do these steps
+once:
 
-    openstack security group list
+    PROJECT_ID=$(openstack project list -f value -c ID \
+	       --domain admin_domain)
 
-For each security group in the list, identify the UUID and run:
+    SECGRP_ID=$(openstack security group list --project $PROJECT_ID \
+        | awk '/default/{print$2}')
 
+    openstack security group rule create $SECGRP_ID \
+        --protocol icmp --ingress --ethertype IPv4
 
-    openstack security group rule create <uuid> \
-        --protocol icmp --remote-ip 0.0.0.0/0
+    openstack security group rule create $SECGRP_ID \
+        --protocol icmp --ingress --ethertype IPv6
 
-    openstack security group rule create <uuid> \
-        --protocol tcp --remote-ip 0.0.0.0/0 --dst-port 22
+    openstack security group rule create $SECGRP_ID \
+        --protocol tcp --ingress --ethertype IPv4 --dst-port 22
+
+    openstack security group rule create $SECGRP_ID \
+        --protocol tcp --ingress --ethertype IPv6 --dst-port 22
 
 After running these commands you should be able to access the instance:
 
-    ssh ubuntu@<new-floating-ip>
+    ssh ubuntu@$FIP
 
 ## What next?
 
@@ -200,4 +224,4 @@ Configuring and managing services on an OpenStack cloud is complex; take a look 
 [Simplestreams]: https://launchpad.net/simplestreams
 [OpenStack Neutron]: http://docs.openstack.org/admin-guide-cloud/content/ch_networking.html
 [OpenStack Admin Guide]: http://docs.openstack.org/user-guide-admin/content
-[Ubuntu Cloud Images]: http://cloud-images.ubuntu.com/eoan/current/
+[Ubuntu Cloud Images]: http://cloud-images.ubuntu.com/bionic/current/

--- a/development/openstack-base-bionic-ussuri-ovn/neutron-ext-net-ksv3
+++ b/development/openstack-base-bionic-ussuri-ovn/neutron-ext-net-ksv3
@@ -1,1 +1,0 @@
-../shared/neutron-ext-net-ksv3

--- a/development/openstack-base-bionic-ussuri-ovn/neutron-tenant-net-ksv3
+++ b/development/openstack-base-bionic-ussuri-ovn/neutron-tenant-net-ksv3
@@ -1,1 +1,0 @@
-../shared/neutron-tenant-net-ksv3

--- a/development/openstack-base-bionic-ussuri/neutron-ext-net-ksv3
+++ b/development/openstack-base-bionic-ussuri/neutron-ext-net-ksv3
@@ -1,1 +1,0 @@
-../shared/neutron-ext-net-ksv3

--- a/development/openstack-base-bionic-ussuri/neutron-tenant-net-ksv3
+++ b/development/openstack-base-bionic-ussuri/neutron-tenant-net-ksv3
@@ -1,1 +1,0 @@
-../shared/neutron-tenant-net-ksv3

--- a/development/openstack-base-focal-ussuri-ovn/README.md
+++ b/development/openstack-base-focal-ussuri-ovn/README.md
@@ -12,7 +12,7 @@ For example, a section similar to this exists in the bundle.yaml file.  The thir
 
 ```
 variables:
-  openstack-origin:    &openstack-origin     cloud:eoan-train
+  openstack-origin:    &openstack-origin     distro
   data-port:           &data-port            br-ex:eno2
   worker-multiplier:   &worker-multiplier    0.25
   osd-devices:         &osd-devices          /dev/sdb /dev/vdb
@@ -94,36 +94,52 @@ You should get a full listing of all services registered in the cloud which shou
 
 In order to run instances on your cloud, you'll need to upload an image to boot instances:
 
-    curl http://cloud-images.ubuntu.com/eoan/current/eoan-server-cloudimg-amd64.img | \
-        openstack image create --public --container-format=bare --disk-format=qcow2 eoan
+    curl https://cloud-images.ubuntu.com/focal/current/focal-server-cloudimg-amd64.img | \
+        openstack image create --public --container-format=bare \
+            --disk-format=qcow2 focal
 
 Images for other architectures can be obtained from [Ubuntu Cloud Images][].  Be sure to use the appropriate image for the cpu architecture.
 
 **Note:** for ARM 64-bit (arm64) guests, you will also need to configure the image to boot in UEFI mode:
 
-    curl http://cloud-images.ubuntu.com/eoan/current/eoan-server-cloudimg-arm64.img | \
-        openstack image create --public --container-format=bare --disk-format=qcow2 --property hw_firmware_type=uefi eoan
+    curl http://cloud-images.ubuntu.com/focal/current/focal-server-cloudimg-arm64.img | \
+        openstack image create --public --container-format=bare \
+            --disk-format=qcow2 --property hw_firmware_type=uefi focal
 
 ### Configure networking
 
-For the purposes of a quick test, we'll setup an 'external' network and shared router ('provider-router') which will be used by all tenants for public access to instances:
-
-    ./neutron-ext-net-ksv3 --network-type flat \
-        -g <gateway-ip> -c <network-cidr> \
-        -f <pool-start>:<pool-end> ext_net
+For the purposes of a quick test, we'll setup an 'external' network and shared
+router ('provider-router') which will be used by all tenants for public access
+to instances:
 
 for example (for a private cloud):
 
-    ./neutron-ext-net-ksv3 --network-type flat \
-        -g 10.230.168.1 -c 10.230.168.0/21 \
-        -f 10.230.168.10:10.230.175.254 ext_net
+    openstack network create --external --provider-network-type flat \
+        --provider-physical-network physnet1 ext_net
 
-You'll need to adapt the parameters for the network configuration that eno2 on all the servers is connected to; in a public cloud deployment these ports would be connected to a publicly addressable part of the Internet.
+    openstack subnet create --subnet-range 192.0.2.0/24 --no-dhcp \
+        --gateway 192.0.2.1 --network ext_net \
+        --allocation-pool start=192.0.2.10,end=192.0.2.254 ext
 
-We'll also need an 'internal' network for the admin user which instances are actually connected to:
+You'll need to adapt the parameters for the network configuration that eno2 on
+all the servers is connected to; in a public cloud deployment these ports would
+be connected to a publicly addressable part of the Internet.
 
-    ./neutron-tenant-net-ksv3 -p admin -r provider-router \
-        [-N <dns-server>] internal 10.5.5.0/24
+We'll also need an 'internal' network for the admin user which instances are
+actually connected to:
+
+    openstack network create internal
+
+    openstack subnet create --network internal \
+        --subnet-range 198.51.100.0/24 \
+        --dns-nameserver 8.8.8.8 \
+        internal_subnet
+
+    openstack router create provider-router
+
+    openstack router set --external-gateway ext_net provider-router
+
+    openstack router add subnet provider-router internal_subnet
 
 Neutron provides a wide range of configuration options; see the [OpenStack Neutron][] documentation for more details.
 
@@ -148,9 +164,8 @@ First generate a SSH keypair so that you can access your instances once you've b
 
 You can now boot an instance on your cloud:
 
-    openstack server create --image eoan --flavor m1.small --key-name mykey \
-        --nic net-id=$(openstack network list | grep internal | awk '{ print $2 }') \
-        eoan-test
+    openstack server create --image focal --flavor m1.small --key-name mykey \
+        --network internal focal-test
 
 ### Attaching a volume
 
@@ -160,33 +175,42 @@ First, create a 10G volume in cinder:
 
 then attach it to the instance we just booted:
 
-    openstack server add volume eoan-test <name-of-volume>
+    openstack server add volume focal-test <name-of-volume>
 
 The attached volume will be accessible once you login to the instance (see below).  It will need to be formatted and mounted!
 
 ### Accessing your instance
 
-In order to access the instance you just booted on the cloud, you'll need to assign a floating IP address to the instance:
+In order to access the instance you just booted on the cloud, you'll need to
+assign a floating IP address to the instance:
 
-    openstack floating ip create ext_net
-    openstack server add floating ip eoan-test <new-floating-ip>
+    FIP=$(openstack floating ip create -f value -c floating_ip_address ext_net)
+    openstack server add floating ip focal-test $FIP
 
-and then allow access via SSH (and ping) - you only need to do these steps once:
+and then allow access via SSH (and ping) - you only need to do these steps
+once:
 
-    openstack security group list
+    PROJECT_ID=$(openstack project list -f value -c ID \
+	       --domain admin_domain)
 
-For each security group in the list, identify the UUID and run:
+    SECGRP_ID=$(openstack security group list --project $PROJECT_ID \
+        | awk '/default/{print$2}')
 
+    openstack security group rule create $SECGRP_ID \
+        --protocol icmp --ingress --ethertype IPv4
 
-    openstack security group rule create <uuid> \
-        --protocol icmp --remote-ip 0.0.0.0/0
+    openstack security group rule create $SECGRP_ID \
+        --protocol icmp --ingress --ethertype IPv6
 
-    openstack security group rule create <uuid> \
-        --protocol tcp --remote-ip 0.0.0.0/0 --dst-port 22
+    openstack security group rule create $SECGRP_ID \
+        --protocol tcp --ingress --ethertype IPv4 --dst-port 22
+
+    openstack security group rule create $SECGRP_ID \
+        --protocol tcp --ingress --ethertype IPv6 --dst-port 22
 
 After running these commands you should be able to access the instance:
 
-    ssh ubuntu@<new-floating-ip>
+    ssh ubuntu@$FIP
 
 ## What next?
 
@@ -200,4 +224,4 @@ Configuring and managing services on an OpenStack cloud is complex; take a look 
 [Simplestreams]: https://launchpad.net/simplestreams
 [OpenStack Neutron]: http://docs.openstack.org/admin-guide-cloud/content/ch_networking.html
 [OpenStack Admin Guide]: http://docs.openstack.org/user-guide-admin/content
-[Ubuntu Cloud Images]: http://cloud-images.ubuntu.com/eoan/current/
+[Ubuntu Cloud Images]: http://cloud-images.ubuntu.com/focal/current/

--- a/development/openstack-base-focal-ussuri-ovn/README.md
+++ b/development/openstack-base-focal-ussuri-ovn/README.md
@@ -12,7 +12,7 @@ For example, a section similar to this exists in the bundle.yaml file.  The thir
 
 ```
 variables:
-  openstack-origin:    &openstack-origin     distro
+  openstack-origin:    &openstack-origin     distro-proposed
   data-port:           &data-port            br-ex:eno2
   worker-multiplier:   &worker-multiplier    0.25
   osd-devices:         &osd-devices          /dev/sdb /dev/vdb

--- a/development/openstack-base-focal-ussuri-ovn/neutron-ext-net-ksv3
+++ b/development/openstack-base-focal-ussuri-ovn/neutron-ext-net-ksv3
@@ -1,1 +1,0 @@
-../shared/neutron-ext-net-ksv3

--- a/development/openstack-base-focal-ussuri-ovn/neutron-tenant-net-ksv3
+++ b/development/openstack-base-focal-ussuri-ovn/neutron-tenant-net-ksv3
@@ -1,1 +1,0 @@
-../shared/neutron-tenant-net-ksv3

--- a/development/openstack-telemetry-bionic-ussuri/neutron-ext-net-ksv3
+++ b/development/openstack-telemetry-bionic-ussuri/neutron-ext-net-ksv3
@@ -1,1 +1,0 @@
-../shared/neutron-ext-net-ksv3

--- a/development/openstack-telemetry-bionic-ussuri/neutron-tenant-net-ksv3
+++ b/development/openstack-telemetry-bionic-ussuri/neutron-tenant-net-ksv3
@@ -1,1 +1,0 @@
-../shared/neutron-tenant-net-ksv3

--- a/development/openstack-telemetry-focal-ussuri-ovn/neutron-ext-net-ksv3
+++ b/development/openstack-telemetry-focal-ussuri-ovn/neutron-ext-net-ksv3
@@ -1,1 +1,0 @@
-../shared/neutron-ext-net-ksv3

--- a/development/openstack-telemetry-focal-ussuri-ovn/neutron-tenant-net-ksv3
+++ b/development/openstack-telemetry-focal-ussuri-ovn/neutron-tenant-net-ksv3
@@ -1,1 +1,0 @@
-../shared/neutron-tenant-net-ksv3

--- a/development/shared/neutron-ext-net-ksv3
+++ b/development/shared/neutron-ext-net-ksv3
@@ -37,7 +37,7 @@ if __name__ == '__main__':
                       dest="floating_range", action="store", default=None)
     parser.add_option("--network-type",
                       help="Network type.",
-                      dest="network_type", action="store", default='gre')
+                      dest="network_type", action="store", default=None)
     parser.add_option(
         "--physical-network",
         help="Physical network if network type is 'vlan' or 'flat'.",
@@ -92,21 +92,27 @@ if __name__ == '__main__':
                 'name': net_name,
                 'router:external': True,
                 'tenant_id': project_id,
-                'provider:network_type': opts.network_type,
             }
         }
 
         if opts.network_type == 'vxlan':
             network_msg['network']['provider:segmentation_id'] = 1234
+            network_msg['network']['provider:network_type'] = opts.network_type
         elif opts.network_type == 'vlan':
             network_msg['network']['provider:segmentation_id'] = opts.vlan_id
             network_msg['network']['provider:physical_network'] = \
                 opts.physical_network
+            network_msg['network']['provider:network_type'] = opts.network_type
         elif opts.network_type == 'flat':
             network_msg['network']['provider:physical_network'] = \
                 opts.physical_network
+            network_msg['network']['provider:network_type'] = opts.network_type
         else:
-            network_msg['network']['provider:segmentation_id'] = 2
+            if opts.network_type:
+                network_msg['network'][
+                    'provider:network_type'] = opts.network_type
+                network_msg['network']['provider:segmentation_id'] = 2
+            # If no network type specified let neutron determine defaults
 
         logging.info('Creating new external network definition: %s', net_name)
         network = quantum.create_network(network_msg)['network']

--- a/development/shared/neutron-tenant-net-ksv3
+++ b/development/shared/neutron-tenant-net-ksv3
@@ -42,7 +42,7 @@ if __name__ == '__main__':
                       dest="dns_servers", action="store",  default=None)
     parser.add_option("--network-type",
                       help="Network type.",
-                      dest="network_type", action="store", default='gre')
+                      dest="network_type", action="store", default=None)
     parser.add_option("--physical-network",
                       help="Physical network if network type is 'vlan'.",
                       dest="physical_network", action="store",
@@ -90,18 +90,23 @@ if __name__ == '__main__':
                 'name': net_name,
                 'shared': opts.shared,
                 'tenant_id': project_id,
-                'provider:network_type': opts.network_type,
             }
         }
 
         if opts.network_type == 'vxlan':
             network_msg['network']['provider:segmentation_id'] = 1233
+            network_msg['network']['provider:network_type'] = opts.network_type
         elif opts.network_type == 'vlan':
             network_msg['network']['provider:segmentation_id'] = 5
             network_msg['network']['provider:physical_network'] = \
                 opts.physical_network
+            network_msg['network']['provider:network_type'] = opts.network_type
         else:
-            network_msg['network']['provider:segmentation_id'] = 5
+            if opts.network_type:
+                network_msg['network'][
+                    'provider:network_type'] = opts.network_type
+                network_msg['network']['provider:segmentation_id'] = 5
+            # If no network type specified let neutron determine defaults
 
         network = quantum.create_network(network_msg)['network']
     else:


### PR DESCRIPTION
While the proprietary Python scripts are valuable for our internal
testing they do not provide much educational value for our end
users.

Replace use of the scripts with examples of how to do post deploy
configuration using the OpenStack CLI for ussuri bundles.