### PR TITLE
Reset OS_AUTH_PROTOCOL and OS_CACERT

### DIFF
--- a/development/shared/openrcv2
+++ b/development/shared/openrcv2
@@ -1,7 +1,5 @@
 _OS_PARAMS=$(env | awk 'BEGIN {FS="="} /^OS_/ {print $1;}' | paste -sd ' ')
 for param in $_OS_PARAMS; do
-    if [ "$param" = "OS_AUTH_PROTOCOL" ]; then continue; fi
-    if [ "$param" = "OS_CACERT" ]; then continue; fi
     unset $param
 done
 

--- a/development/shared/openrcv3_domain
+++ b/development/shared/openrcv3_domain
@@ -1,7 +1,5 @@
 _OS_PARAMS=$(env | awk 'BEGIN {FS="="} /^OS_/ {print $1;}' | paste -sd ' ')
 for param in $_OS_PARAMS; do
-    if [ "$param" = "OS_AUTH_PROTOCOL" ]; then continue; fi
-    if [ "$param" = "OS_CACERT" ]; then continue; fi
     unset $param
 done
 unset _OS_PARAMS

--- a/development/shared/openrcv3_project
+++ b/development/shared/openrcv3_project
@@ -1,7 +1,5 @@
 _OS_PARAMS=$(env | awk 'BEGIN {FS="="} /^OS_/ {print $1;}' | paste -sd ' ')
 for param in $_OS_PARAMS; do
-    if [ "$param" = "OS_AUTH_PROTOCOL" ]; then continue; fi
-    if [ "$param" = "OS_CACERT" ]; then continue; fi
     unset $param
 done
 unset _OS_PARAMS

--- a/stable/shared/openrcv2
+++ b/stable/shared/openrcv2
@@ -1,7 +1,5 @@
 _OS_PARAMS=$(env | awk 'BEGIN {FS="="} /^OS_/ {print $1;}' | paste -sd ' ')
 for param in $_OS_PARAMS; do
-    if [ "$param" = "OS_AUTH_PROTOCOL" ]; then continue; fi
-    if [ "$param" = "OS_CACERT" ]; then continue; fi
     unset $param
 done
 

--- a/stable/shared/openrcv3_domain
+++ b/stable/shared/openrcv3_domain
@@ -1,7 +1,5 @@
 _OS_PARAMS=$(env | awk 'BEGIN {FS="="} /^OS_/ {print $1;}' | paste -sd ' ')
 for param in $_OS_PARAMS; do
-    if [ "$param" = "OS_AUTH_PROTOCOL" ]; then continue; fi
-    if [ "$param" = "OS_CACERT" ]; then continue; fi
     unset $param
 done
 unset _OS_PARAMS

--- a/stable/shared/openrcv3_project
+++ b/stable/shared/openrcv3_project
@@ -1,7 +1,5 @@
 _OS_PARAMS=$(env | awk 'BEGIN {FS="="} /^OS_/ {print $1;}' | paste -sd ' ')
 for param in $_OS_PARAMS; do
-    if [ "$param" = "OS_AUTH_PROTOCOL" ]; then continue; fi
-    if [ "$param" = "OS_CACERT" ]; then continue; fi
     unset $param
 done
 unset _OS_PARAMS


### PR DESCRIPTION
Just as every other OS_* setting is reset OS_AUTH_PROTOCOL and OS_CACERT
should also be reset.

Closes-Bug: #1883290