### PR TITLE
Warn user that bundle and overlay must have matching openstack-origin

### DIFF
--- a/development/overlays/loadbalancer-octavia.yaml
+++ b/development/overlays/loadbalancer-octavia.yaml
@@ -1,4 +1,7 @@
 # Loadbalancer (LBAASv2) with Octavia - requires Rocky or later
+#
+# WARNING: before using this overlay, make sure `openstack-origin` here and in
+# your deployment bundle match.
 ---
 applications:
   barbican:

--- a/development/overlays/masakari-bionic-ussuri.yaml
+++ b/development/overlays/masakari-bionic-ussuri.yaml
@@ -7,6 +7,9 @@
 #  masakari:
 #    options:
 #      vip: <INSERT VIP(S)>
+#
+# WARNING: before using this overlay, make sure `openstack-origin` here and in
+# your deployment bundle match.
 ---
 machines:
   '0':


### PR DESCRIPTION
https://bugs.launchpad.net/openstack-bundles/+bug/1895662