### PR TITLE
Fix openrc symlinks

### DIFF
--- a/development/openstack-base-focal-ussuri-ovn/openrc
+++ b/development/openstack-base-focal-ussuri-ovn/openrc
@@ -1,1 +1,1 @@
-openrcv3_project
+../shared/openrc

--- a/development/openstack-base-focal-victoria/openrc
+++ b/development/openstack-base-focal-victoria/openrc
@@ -1,1 +1,1 @@
-openrcv3_project
+../shared/openrc

--- a/development/openstack-base-focal-wallaby/openrc
+++ b/development/openstack-base-focal-wallaby/openrc
@@ -1,1 +1,1 @@
-openrcv3_project
+../shared/openrc

--- a/development/openstack-base-groovy-victoria/openrc
+++ b/development/openstack-base-groovy-victoria/openrc
@@ -1,1 +1,1 @@
-openrcv3_project
+../shared/openrc

--- a/development/openstack-telemetry-focal-ussuri-ovn/openrc
+++ b/development/openstack-telemetry-focal-ussuri-ovn/openrc
@@ -1,1 +1,1 @@
-openrcv3_project
+../shared/openrc

--- a/development/openstack-telemetry-focal-victoria/openrc
+++ b/development/openstack-telemetry-focal-victoria/openrc
@@ -1,1 +1,1 @@
-openrcv3_project
+../shared/openrc

--- a/development/openstack-telemetry-focal-wallaby/openrc
+++ b/development/openstack-telemetry-focal-wallaby/openrc
@@ -1,1 +1,1 @@
-openrcv3_project
+../shared/openrc

--- a/development/openstack-telemetry-groovy-victoria/openrc
+++ b/development/openstack-telemetry-groovy-victoria/openrc
@@ -1,1 +1,1 @@
-openrcv3_project
+../shared/openrc


### PR DESCRIPTION
I'm reverting here a mistake I did recently. Without this fix, you'll get an HTTP/400 from keystone when talking to the API. Validated on an arm64 lab.