### PR TITLE
Add ceph-base-groovy-octopus bundle

### DIFF
--- a/development/ceph-base-groovy-octopus/README.md
+++ b/development/ceph-base-groovy-octopus/README.md
@@ -1,0 +1,40 @@
+# Basic Ceph Cluster
+
+*DEV/TEST ONLY*: This unstable, development example bundle deploys a Ceph (Octopus) cluster on Ubuntu 20.04 LTS. See also: [Stable Bundles](https://jujucharms.com/u/openstack-charmers).
+
+## Requirements
+
+This example bundle is designed to run on bare metal using Juju with [MAAS][] (Metal-as-a-Service); you will need to have setup a [MAAS][] deployment with a minimum of 3 physical servers prior to using this bundle.
+
+Certain configuration options within the bundle may need to be adjusted prior to deployment to fit your particular set of hardware. For example, network device names and block device names can vary.
+
+Servers should have:
+
+ - A minimum of 8GB of physical RAM.
+ - Enough CPU cores to support your capacity requirements.
+ - Two disks (identified by /dev/sda and /dev/sdb); the first is used by MAAS for the OS install, the second for Ceph storage.
+
+## Components
+ - 3 Nodes for Ceph OSDs
+ - 3 Ceph monitors in LXD containers on the OSD machines
+
+All physical servers (not LXD containers) will also have NTP installed and configured to keep time in sync.
+
+To horizontally scale Ceph:
+
+    juju add-unit ceph-osd # Add one more unit
+    juju add-unit -n50 ceph-osd # add 50 more units
+
+## Ensuring it's working
+
+To ensure your cluster is functioning correctly, run through the following commands.
+
+Connect to a monitor shell:
+
+    juju ssh ceph-mon/0
+
+Check that the cluster is healthy:
+
+    sudo ceph -s
+
+[MAAS]: https://maas.io/

--- a/development/ceph-base-groovy-octopus/bundle.yaml
+++ b/development/ceph-base-groovy-octopus/bundle.yaml
@@ -1,0 +1,38 @@
+machines:
+  '0':
+    series: groovy
+  '1':
+    series: groovy
+  '2':
+    series: groovy
+relations:
+- - ceph-osd:mon
+  - ceph-mon:osd
+series: groovy
+services:
+  ceph-mon:
+    annotations:
+      gui-x: '750'
+      gui-y: '500'
+    charm: cs:~openstack-charmers-next/ceph-mon
+    num_units: 3
+    options:
+      expected-osd-count: 3
+      source: distro
+    to:
+    - lxd:0
+    - lxd:1
+    - lxd:2
+  ceph-osd:
+    annotations:
+      gui-x: '1000'
+      gui-y: '500'
+    charm: cs:~openstack-charmers-next/ceph-osd
+    num_units: 3
+    options:
+      osd-devices: /dev/sdb
+      source: distro
+    to:
+    - '0'
+    - '1'
+    - '2'

--- a/development/ceph-base-groovy-octopus/test-requirements.txt
+++ b/development/ceph-base-groovy-octopus/test-requirements.txt
@@ -1,0 +1,1 @@
+../shared/test-requirements.txt

--- a/development/ceph-base-groovy-octopus/tests/bundles/bundle.yaml
+++ b/development/ceph-base-groovy-octopus/tests/bundles/bundle.yaml
@@ -1,0 +1,1 @@
+../../bundle.yaml

--- a/development/ceph-base-groovy-octopus/tests/bundles/overlays/bundle.yaml.j2
+++ b/development/ceph-base-groovy-octopus/tests/bundles/overlays/bundle.yaml.j2
@@ -1,0 +1,1 @@
+../../../../overlays/ceph-base-virt-overlay.yaml

--- a/development/ceph-base-groovy-octopus/tests/tests.yaml
+++ b/development/ceph-base-groovy-octopus/tests/tests.yaml
@@ -1,0 +1,11 @@
+configure: []
+dev_bundles: []
+gate_bundles:
+  - bundle
+smoke_bundles: []
+tests:
+  - zaza.openstack.charm_tests.ceph.osd.tests.SecurityTest
+  - zaza.openstack.charm_tests.ceph.osd.tests.ServiceTest
+tests_options:
+  force_deploy:
+    - bundle

--- a/development/ceph-base-groovy-octopus/tox.ini
+++ b/development/ceph-base-groovy-octopus/tox.ini
@@ -1,0 +1,1 @@
+../shared/tox.ini

--- a/development/ceph-base-groovy-octopus/validate-ceph.sh
+++ b/development/ceph-base-groovy-octopus/validate-ceph.sh
@@ -1,0 +1,1 @@
+../shared/validate-ceph.sh


### PR DESCRIPTION
This is just a copy of `ceph-base-focal-octopus` with `s/focal/groovy/`