### PR TITLE
Fix Ceph version in dev openstack-base README

### DIFF
--- a/development/openstack-base-focal-wallaby/README.md
+++ b/development/openstack-base-focal-wallaby/README.md
@@ -8,7 +8,7 @@ include:
 
 * Ubuntu 20.04 LTS (Focal)
 * OpenStack Wallaby
-* Ceph Octopus
+* Ceph Pacific
 
 Cloud services consist of Compute, Network, Block Storage, Object Storage,
 Identity, Image, and Dashboard.


### PR DESCRIPTION
The focal-wallaby openstack-base bundle README needed a correction in the Ceph version provided.