### PR TITLE
[DO-NOT-MERGE] Illustrate https://bugs.launchpad.net/charm-ceilometer/+bug/1906623

### DIFF
--- a/development/openstack-telemetry-focal-victoria/bundle.yaml
+++ b/development/openstack-telemetry-focal-victoria/bundle.yaml
@@ -14,10 +14,13 @@ variables:
 machines:
   '0':
     series: focal
+    constraints: arch=arm64
   '1':
     series: focal
+    constraints: arch=arm64
   '2':
     series: focal
+    constraints: arch=arm64
 relations:
 - - nova-compute:amqp
   - rabbitmq-server:amqp

--- a/development/openstack-telemetry-focal-victoria/tests/bundles/overlays/bundle.yaml.j2
+++ b/development/openstack-telemetry-focal-victoria/tests/bundles/overlays/bundle.yaml.j2
@@ -1,1 +1,0 @@
-../../../../overlays/openstack-base-virt-overlay.yaml

--- a/development/openstack-telemetry-focal-victoria/tests/tests.yaml
+++ b/development/openstack-telemetry-focal-victoria/tests/tests.yaml
@@ -5,8 +5,11 @@ configure:
   - zaza.openstack.charm_tests.nova.setup.manage_ssh_key
   - zaza.openstack.charm_tests.neutron.setup.basic_overcloud_network
   - zaza.openstack.charm_tests.glance.setup.add_lts_image
+  # Fails with `Keystone temporarily unavailable`:
+  - zaza.openstack.charm_tests.ceilometer.setup.basic_setup
 tests:
   - zaza.openstack.charm_tests.nova.tests.LTSGuestCreateTest
+  - zaza.openstack.charm_tests.ceilometer.tests.CeilometerTest
 target_deploy_status:
   neutron-api-plugin-ovn:
     workload-status: waiting


### PR DESCRIPTION
Reproduce by deploying on arm64:

```
$ cd openstack-bundles/development/openstack-telemetry-focal-victoria/
$ export TEST_IMAGE_ARCH=arm64
$ export TEST_GATEWAY=10.245.168.1
$ export TEST_CIDR_EXT=10.245.168.0/21
$ export TEST_FIP_RANGE=10.245.168.140:10.245.168.150
$ tox -e func
```