### PR TITLE
Comment out bridge-interface-mappings as it is environment specific

### DIFF
--- a/development/openstack-base-bionic-stein/bundle.yaml
+++ b/development/openstack-base-bionic-stein/bundle.yaml
@@ -1,6 +1,12 @@
+# Please refer to the OpenStack Charms Deployment Guide for more information.
+# https://docs.openstack.org/project-deploy-guide/charm-deployment-guide
+#
+# NOTE: Please review the value for the configuration option
+#       `bridge-interface-mappings` for the `ovn-chassis` charm (see `data-port` variable).
+
 variables:
   openstack-origin:    &openstack-origin     cloud:bionic-stein
-  data-port:           &data-port            br-ex:eno2
+  data-port:           &data-port            null
   worker-multiplier:   &worker-multiplier    0.25
   osd-devices:         &osd-devices          /dev/sdb /dev/vdb
   expected-osd-count:  &expected-osd-count   3

--- a/development/openstack-base-bionic-train/bundle.yaml
+++ b/development/openstack-base-bionic-train/bundle.yaml
@@ -1,6 +1,12 @@
+# Please refer to the OpenStack Charms Deployment Guide for more information.
+# https://docs.openstack.org/project-deploy-guide/charm-deployment-guide
+#
+# NOTE: Please review the value for the configuration option
+#       `bridge-interface-mappings` for the `ovn-chassis` charm (see `data-port` variable).
+
 variables:
   openstack-origin:    &openstack-origin     cloud:bionic-train
-  data-port:           &data-port            br-ex:eno2
+  data-port:           &data-port            null
   worker-multiplier:   &worker-multiplier    0.25
   osd-devices:         &osd-devices          /dev/sdb /dev/vdb
   expected-osd-count:  &expected-osd-count   3

--- a/development/openstack-base-bionic-ussuri-ovn/bundle.yaml
+++ b/development/openstack-base-bionic-ussuri-ovn/bundle.yaml
@@ -1,16 +1,19 @@
 # Open Virtual Network (OVN) - requires Train or later
 #
+# Please refer to the OpenStack Charms Deployment Guide for more information.
+# https://docs.openstack.org/project-deploy-guide/charm-deployment-guide
+#
 # NOTE: Please review the value for the configuration option
-#       `bridge-interface-mappings` for the `ovn-chassis` charm.
+#       `bridge-interface-mappings` for the `ovn-chassis` charm (see `data-port` variable).
 #       Refer to the [Open Virtual Network (OVN)](https://docs.openstack.org/project-deploy-guide/charm-deployment-guide/latest/app-ovn.html)
 #       section of the [OpenStack Charms Deployment Guide](https://docs.openstack.org/project-deploy-guide/charm-deployment-guide/latest/)
 #       for more information.
----
+
 local_overlay_enabled: true
 series: bionic
 variables:
   openstack-origin:    &openstack-origin     cloud:bionic-ussuri
-  data-port:           &data-port            br-ex:eno2
+  data-port:           &data-port            null
   worker-multiplier:   &worker-multiplier    0.25
   osd-devices:         &osd-devices          /dev/sdb /dev/vdb
   expected-osd-count:  &expected-osd-count   3
@@ -309,10 +312,9 @@ applications:
     - 'lxd:2'
   ovn-chassis:
     charm: cs:~openstack-charmers-next/ovn-chassis
-    comment: |
-      Please update the `bridge-interface-mappings` to values suitable for the
-      hardware used in your deployment.  See the referenced documentation at
-      the top of this file.
+    # Please update the `bridge-interface-mappings` to values suitable for the
+    # hardware used in your deployment. See the referenced documentation at the
+    # top of this file.
     options:
       ovn-bridge-mappings: physnet1:br-ex
       bridge-interface-mappings: *data-port

--- a/development/openstack-base-bionic-ussuri/bundle.yaml
+++ b/development/openstack-base-bionic-ussuri/bundle.yaml
@@ -1,6 +1,12 @@
+# Please refer to the OpenStack Charms Deployment Guide for more information.
+# https://docs.openstack.org/project-deploy-guide/charm-deployment-guide
+#
+# NOTE: Please review the value for the configuration option
+#       `bridge-interface-mappings` for the `ovn-chassis` charm (see `data-port` variable).
+
 variables:
   openstack-origin:    &openstack-origin     cloud:bionic-ussuri
-  data-port:           &data-port            br-ex:eno2
+  data-port:           &data-port            null
   worker-multiplier:   &worker-multiplier    0.25
   osd-devices:         &osd-devices          /dev/sdb /dev/vdb
   expected-osd-count:  &expected-osd-count   3

--- a/development/openstack-base-eoan-train-mysql8-migration/bundle.yaml
+++ b/development/openstack-base-eoan-train-mysql8-migration/bundle.yaml
@@ -1,16 +1,19 @@
 # Open Virtual Network (OVN) - requires Train or later
 #
+# Please refer to the OpenStack Charms Deployment Guide for more information.
+# https://docs.openstack.org/project-deploy-guide/charm-deployment-guide
+#
 # NOTE: Please review the value for the configuration option
-#       `bridge-interface-mappings` for the `ovn-chassis` charm.
+#       `bridge-interface-mappings` for the `ovn-chassis` charm (see `data-port` variable).
 #       Refer to the [Open Virtual Network (OVN)](https://docs.openstack.org/project-deploy-guide/charm-deployment-guide/latest/app-ovn.html)
 #       section of the [OpenStack Charms Deployment Guide](https://docs.openstack.org/project-deploy-guide/charm-deployment-guide/latest/)
 #       for more information.
----
+
 local_overlay_enabled: true
 series: eoan
 variables:
   openstack-origin:    &openstack-origin     distro
-  data-port:           &data-port            br-ex:eno2
+  data-port:           &data-port            null
   worker-multiplier:   &worker-multiplier    0.25
   osd-devices:         &osd-devices          /dev/sdb /dev/vdb
   expected-osd-count:  &expected-osd-count   3
@@ -314,13 +317,12 @@ applications:
     - 'lxd:2'
   ovn-chassis:
     charm: cs:~openstack-charmers/ovn-chassis
-    comment: |
-      Please update the `bridge-interface-mappings` to values suitable for the
-      hardware used in your deployment.  See the referenced documentation at
-      the top of this file.
+    # Please update the `bridge-interface-mappings` to values suitable for the
+    # hardware used in your deployment. See the referenced documentation at the
+    # top of this file.
     options:
       ovn-bridge-mappings: physnet1:br-provider
-      bridge-interface-mappings: br-provider:00:00:5e:00:00:42 br-provider:00:00:5e:00:00:51
+      bridge-interface-mappings: *data-port
   vault:
     charm: cs:vault
     num_units: 1

--- a/development/openstack-base-eoan-train-mysql8-ovn/bundle.yaml
+++ b/development/openstack-base-eoan-train-mysql8-ovn/bundle.yaml
@@ -1,16 +1,19 @@
 # Open Virtual Network (OVN) - requires Train or later
 #
+# Please refer to the OpenStack Charms Deployment Guide for more information.
+# https://docs.openstack.org/project-deploy-guide/charm-deployment-guide
+#
 # NOTE: Please review the value for the configuration option
-#       `bridge-interface-mappings` for the `ovn-chassis` charm.
+#       `bridge-interface-mappings` for the `ovn-chassis` charm (see `data-port` variable).
 #       Refer to the [Open Virtual Network (OVN)](https://docs.openstack.org/project-deploy-guide/charm-deployment-guide/latest/app-ovn.html)
 #       section of the [OpenStack Charms Deployment Guide](https://docs.openstack.org/project-deploy-guide/charm-deployment-guide/latest/)
 #       for more information.
----
+
 local_overlay_enabled: true
 series: eoan
 variables:
   openstack-origin:    &openstack-origin     distro
-  data-port:           &data-port            br-ex:eno2
+  data-port:           &data-port            null
   worker-multiplier:   &worker-multiplier    0.25
   osd-devices:         &osd-devices          /dev/sdb /dev/vdb
   expected-osd-count:  &expected-osd-count   3
@@ -328,10 +331,9 @@ applications:
     - 'lxd:2'
   ovn-chassis:
     charm: cs:~openstack-charmers-next/ovn-chassis
-    comment: |
-      Please update the `bridge-interface-mappings` to values suitable for the
-      hardware used in your deployment.  See the referenced documentation at
-      the top of this file.
+    # Please update the `bridge-interface-mappings` to values suitable for the
+    # hardware used in your deployment. See the referenced documentation at the
+    # top of this file.
     options:
       ovn-bridge-mappings: physnet1:br-ex
       bridge-interface-mappings: *data-port

--- a/development/openstack-base-eoan-train/bundle.yaml
+++ b/development/openstack-base-eoan-train/bundle.yaml
@@ -1,6 +1,12 @@
+# Please refer to the OpenStack Charms Deployment Guide for more information.
+# https://docs.openstack.org/project-deploy-guide/charm-deployment-guide
+#
+# NOTE: Please review the value for the configuration option
+#       `bridge-interface-mappings` for the `ovn-chassis` charm (see `data-port` variable).
+
 variables:
   openstack-origin:    &openstack-origin     distro
-  data-port:           &data-port            br-ex:eno2
+  data-port:           &data-port            null
   worker-multiplier:   &worker-multiplier    0.25
   osd-devices:         &osd-devices          /dev/sdb /dev/vdb
   expected-osd-count:  &expected-osd-count   3

--- a/development/openstack-base-focal-ussuri-ovn/bundle.yaml
+++ b/development/openstack-base-focal-ussuri-ovn/bundle.yaml
@@ -1,12 +1,17 @@
----
+# Please refer to the OpenStack Charms Deployment Guide for more information.
+# https://docs.openstack.org/project-deploy-guide/charm-deployment-guide
+#
+# NOTE: Please review the value for the configuration option
+#       `bridge-interface-mappings` for the `ovn-chassis` charm (see `data-port` variable).
+#       Refer to the [Open Virtual Network (OVN)](https://docs.openstack.org/project-deploy-guide/charm-deployment-guide/latest/app-ovn.html)
+#       section of the [OpenStack Charms Deployment Guide](https://docs.openstack.org/project-deploy-guide/charm-deployment-guide/latest/)
+#       for more information.
+
 local_overlay_enabled: true
 series: focal
-# *** Please refer to the OpenStack Charms Deployment Guide for more        ***
-# *** information.
-# *** https://docs.openstack.org/project-deploy-guide/charm-deployment-guide **
 variables:
   openstack-origin: &openstack-origin distro
-  data-port: &data-port br-ex:eno2
+  data-port: &data-port null
   worker-multiplier: &worker-multiplier 0.25
   osd-devices: &osd-devices /dev/sdb /dev/vdb
   expected-osd-count: &expected-osd-count 3
@@ -359,9 +364,9 @@ applications:
       gui-x: '120'
       gui-y: '1030'
     charm: cs:~openstack-charmers-next/ovn-chassis
-    # *** Please update the `bridge-interface-mappings` to values suitable ***
-    # *** for thehardware used in your deployment.  See the referenced     ***
-    # *** documentation at the top of this file.                           ***
+    # Please update the `bridge-interface-mappings` to values suitable for the
+    # hardware used in your deployment. See the referenced documentation at the
+    # top of this file.
     options:
       ovn-bridge-mappings: physnet1:br-ex
       bridge-interface-mappings: *data-port

--- a/development/openstack-base-focal-victoria/bundle.yaml
+++ b/development/openstack-base-focal-victoria/bundle.yaml
@@ -1,12 +1,17 @@
----
+# Please refer to the OpenStack Charms Deployment Guide for more information.
+# https://docs.openstack.org/project-deploy-guide/charm-deployment-guide
+#
+# NOTE: Please review the value for the configuration option
+#       `bridge-interface-mappings` for the `ovn-chassis` charm (see `data-port` variable).
+#       Refer to the [Open Virtual Network (OVN)](https://docs.openstack.org/project-deploy-guide/charm-deployment-guide/latest/app-ovn.html)
+#       section of the [OpenStack Charms Deployment Guide](https://docs.openstack.org/project-deploy-guide/charm-deployment-guide/latest/)
+#       for more information.
+
 local_overlay_enabled: true
 series: focal
-# *** Please refer to the OpenStack Charms Deployment Guide for more        ***
-# *** information.
-# *** https://docs.openstack.org/project-deploy-guide/charm-deployment-guide **
 variables:
   openstack-origin: &openstack-origin cloud:focal-victoria
-  data-port: &data-port br-ex:eno2
+  data-port: &data-port null
   worker-multiplier: &worker-multiplier 0.25
   osd-devices: &osd-devices /dev/sdb /dev/vdb
   expected-osd-count: &expected-osd-count 3
@@ -359,9 +364,9 @@ applications:
       gui-x: '120'
       gui-y: '1030'
     charm: cs:~openstack-charmers-next/ovn-chassis
-    # *** Please update the `bridge-interface-mappings` to values suitable ***
-    # *** for thehardware used in your deployment.  See the referenced     ***
-    # *** documentation at the top of this file.                           ***
+    # Please update the `bridge-interface-mappings` to values suitable for the
+    # hardware used in your deployment. See the referenced documentation at the
+    # top of this file.
     options:
       ovn-bridge-mappings: physnet1:br-ex
       bridge-interface-mappings: *data-port

--- a/development/openstack-base-focal-wallaby/bundle.yaml
+++ b/development/openstack-base-focal-wallaby/bundle.yaml
@@ -1,10 +1,16 @@
 # Please refer to the OpenStack Charms Deployment Guide for more information.
 # https://docs.openstack.org/project-deploy-guide/charm-deployment-guide
+#
+# NOTE: Please review the value for the configuration option
+#       `bridge-interface-mappings` for the `ovn-chassis` charm (see `data-port` variable).
+#       Refer to the [Open Virtual Network (OVN)](https://docs.openstack.org/project-deploy-guide/charm-deployment-guide/latest/app-ovn.html)
+#       section of the [OpenStack Charms Deployment Guide](https://docs.openstack.org/project-deploy-guide/charm-deployment-guide/latest/)
+#       for more information.
 
 series: focal
 variables:
   openstack-origin: &openstack-origin cloud:focal-wallaby
-  data-port: &data-port br-ex:eno2
+  data-port: &data-port null
   worker-multiplier: &worker-multiplier 0.25
   osd-devices: &osd-devices /dev/sdb /dev/vdb
   expected-osd-count: &expected-osd-count 3

--- a/development/openstack-base-focal-xena/bundle.yaml
+++ b/development/openstack-base-focal-xena/bundle.yaml
@@ -1,10 +1,16 @@
 # Please refer to the OpenStack Charms Deployment Guide for more information.
 # https://docs.openstack.org/project-deploy-guide/charm-deployment-guide
+#
+# NOTE: Please review the value for the configuration option
+#       `bridge-interface-mappings` for the `ovn-chassis` charm (see `data-port` variable).
+#       Refer to the [Open Virtual Network (OVN)](https://docs.openstack.org/project-deploy-guide/charm-deployment-guide/latest/app-ovn.html)
+#       section of the [OpenStack Charms Deployment Guide](https://docs.openstack.org/project-deploy-guide/charm-deployment-guide/latest/)
+#       for more information.
 
 series: focal
 variables:
   openstack-origin: &openstack-origin cloud:focal-xena
-  data-port: &data-port br-ex:eno2
+  data-port: &data-port null
   worker-multiplier: &worker-multiplier 0.25
   osd-devices: &osd-devices /dev/sdb /dev/vdb
   expected-osd-count: &expected-osd-count 3

--- a/development/openstack-base-groovy-victoria/bundle.yaml
+++ b/development/openstack-base-groovy-victoria/bundle.yaml
@@ -1,12 +1,17 @@
----
+# Please refer to the OpenStack Charms Deployment Guide for more information.
+# https://docs.openstack.org/project-deploy-guide/charm-deployment-guide
+#
+# NOTE: Please review the value for the configuration option
+#       `bridge-interface-mappings` for the `ovn-chassis` charm (see `data-port` variable).
+#       Refer to the [Open Virtual Network (OVN)](https://docs.openstack.org/project-deploy-guide/charm-deployment-guide/latest/app-ovn.html)
+#       section of the [OpenStack Charms Deployment Guide](https://docs.openstack.org/project-deploy-guide/charm-deployment-guide/latest/)
+#       for more information.
+
 local_overlay_enabled: true
 series: groovy
-# *** Please refer to the OpenStack Charms Deployment Guide for more        ***
-# *** information.
-# *** https://docs.openstack.org/project-deploy-guide/charm-deployment-guide **
 variables:
   openstack-origin: &openstack-origin distro
-  data-port: &data-port br-ex:eno2
+  data-port: &data-port null
   worker-multiplier: &worker-multiplier 0.25
   osd-devices: &osd-devices /dev/sdb /dev/vdb
   expected-osd-count: &expected-osd-count 3
@@ -359,9 +364,9 @@ applications:
       gui-x: '120'
       gui-y: '1030'
     charm: cs:~openstack-charmers-next/ovn-chassis
-    # *** Please update the `bridge-interface-mappings` to values suitable ***
-    # *** for thehardware used in your deployment.  See the referenced     ***
-    # *** documentation at the top of this file.                           ***
+    # Please update the `bridge-interface-mappings` to values suitable for the
+    # hardware used in your deployment. See the referenced documentation at the
+    # top of this file.
     options:
       ovn-bridge-mappings: physnet1:br-ex
       bridge-interface-mappings: *data-port

--- a/development/openstack-base-hirsute-wallaby/bundle.yaml
+++ b/development/openstack-base-hirsute-wallaby/bundle.yaml
@@ -1,10 +1,16 @@
 # Please refer to the OpenStack Charms Deployment Guide for more information.
 # https://docs.openstack.org/project-deploy-guide/charm-deployment-guide
+#
+# NOTE: Please review the value for the configuration option
+#       `bridge-interface-mappings` for the `ovn-chassis` charm (see `data-port` variable).
+#       Refer to the [Open Virtual Network (OVN)](https://docs.openstack.org/project-deploy-guide/charm-deployment-guide/latest/app-ovn.html)
+#       section of the [OpenStack Charms Deployment Guide](https://docs.openstack.org/project-deploy-guide/charm-deployment-guide/latest/)
+#       for more information.
 
 series: hirsute
 variables:
   openstack-origin: &openstack-origin distro
-  data-port: &data-port br-ex:eno2
+  data-port: &data-port null
   worker-multiplier: &worker-multiplier 0.25
   osd-devices: &osd-devices /dev/sdb /dev/vdb
   expected-osd-count: &expected-osd-count 3

--- a/development/openstack-base-impish-xena/bundle.yaml
+++ b/development/openstack-base-impish-xena/bundle.yaml
@@ -1,10 +1,16 @@
 # Please refer to the OpenStack Charms Deployment Guide for more information.
 # https://docs.openstack.org/project-deploy-guide/charm-deployment-guide
+#
+# NOTE: Please review the value for the configuration option
+#       `bridge-interface-mappings` for the `ovn-chassis` charm (see `data-port` variable).
+#       Refer to the [Open Virtual Network (OVN)](https://docs.openstack.org/project-deploy-guide/charm-deployment-guide/latest/app-ovn.html)
+#       section of the [OpenStack Charms Deployment Guide](https://docs.openstack.org/project-deploy-guide/charm-deployment-guide/latest/)
+#       for more information.
 
 series: impish
 variables:
   openstack-origin: &openstack-origin distro
-  data-port: &data-port br-ex:eno2
+  data-port: &data-port null
   worker-multiplier: &worker-multiplier 0.25
   osd-devices: &osd-devices /dev/sdb /dev/vdb
   expected-osd-count: &expected-osd-count 3

--- a/development/openstack-converged-networking-focal-ussuri/bundle.yaml
+++ b/development/openstack-converged-networking-focal-ussuri/bundle.yaml
@@ -1,11 +1,17 @@
+# Please refer to the OpenStack Charms Deployment Guide for more information.
+# https://docs.openstack.org/project-deploy-guide/charm-deployment-guide
+#
+# NOTE: Please review the value for the configuration option
+#       `bridge-interface-mappings` for the `ovn-chassis` charm (see `data-port` variable).
+#       Refer to the [Open Virtual Network (OVN)](https://docs.openstack.org/project-deploy-guide/charm-deployment-guide/latest/app-ovn.html)
+#       section of the [OpenStack Charms Deployment Guide](https://docs.openstack.org/project-deploy-guide/charm-deployment-guide/latest/)
+#       for more information.
+
 local_overlay_enabled: true
 series: focal
-# *** Please refer to the OpenStack Charms Deployment Guide for more        ***
-# *** information.
-# *** https://docs.openstack.org/project-deploy-guide/charm-deployment-guide **
 variables:
   openstack-origin: &openstack-origin distro-proposed
-  data-port: &data-port br-ex:bond0
+  data-port: &data-port null
   worker-multiplier: &worker-multiplier 0.25
   osd-devices: &osd-devices /dev/sdb /dev/vdb
   expected-osd-count: &expected-osd-count 3
@@ -357,9 +363,9 @@ applications:
       gui-x: '120'
       gui-y: '1030'
     charm: cs:ovn-chassis-6
-    # *** Please update the `bridge-interface-mappings` to values suitable ***
-    # *** for thehardware used in your deployment.  See the referenced     ***
-    # *** documentation at the top of this file.                           ***
+    # Please update the `bridge-interface-mappings` to values suitable for the
+    # hardware used in your deployment. See the referenced documentation at the
+    # top of this file.
     options:
       ovn-bridge-mappings: physnet1:br-ex
       bridge-interface-mappings: *data-port

--- a/development/openstack-ha/masakari-mosci.yaml
+++ b/development/openstack-ha/masakari-mosci.yaml
@@ -1,6 +1,12 @@
+# Please refer to the OpenStack Charms Deployment Guide for more information.
+# https://docs.openstack.org/project-deploy-guide/charm-deployment-guide
+#
+# NOTE: Please review the value for the configuration option
+#       `bridge-interface-mappings` for the `neutron-gateway` charm (see `data-port` variable).
+
 variables:
   openstack-origin:    &openstack-origin     cloud:bionic-ussuri
-  data-port:           &data-port            br-ex:eno2
+  data-port:           &data-port            null
   worker-multiplier:   &worker-multiplier    0.25
   osd-devices:         &osd-devices          /dev/sdb /dev/vdb
   expected-osd-count:  &expected-osd-count   3
@@ -266,6 +272,9 @@ services:
       gui-x: '0'
       gui-y: '0'
     charm: cs:~openstack-charmers-next/neutron-gateway
+    # Please update the `bridge-interface-mappings` to values suitable for the
+    # hardware used in your deployment. See the referenced documentation at the
+    # top of this file.
     num_units: 1
     options:
       openstack-origin: *openstack-origin

--- a/development/openstack-telemetry-bionic-stein/bundle.yaml
+++ b/development/openstack-telemetry-bionic-stein/bundle.yaml
@@ -1,6 +1,12 @@
+# Please refer to the OpenStack Charms Deployment Guide for more information.
+# https://docs.openstack.org/project-deploy-guide/charm-deployment-guide
+#
+# NOTE: Please review the value for the configuration option
+#       `bridge-interface-mappings` for the `ovn-chassis` charm (see `data-port` variable).
+
 variables:
   openstack-origin:    &openstack-origin     cloud:bionic-stein
-  data-port:           &data-port            br-ex:eno2
+  data-port:           &data-port            null
   worker-multiplier:   &worker-multiplier    0.25
   osd-devices:         &osd-devices          /dev/sdb /dev/vdb
   expected-osd-count:  &expected-osd-count   3

--- a/development/openstack-telemetry-bionic-train/bundle.yaml
+++ b/development/openstack-telemetry-bionic-train/bundle.yaml
@@ -1,6 +1,12 @@
+# Please refer to the OpenStack Charms Deployment Guide for more information.
+# https://docs.openstack.org/project-deploy-guide/charm-deployment-guide
+#
+# NOTE: Please review the value for the configuration option
+#       `bridge-interface-mappings` for the `ovn-chassis` charm (see `data-port` variable).
+
 variables:
   openstack-origin:    &openstack-origin     cloud:bionic-train
-  data-port:           &data-port            br-ex:eno2
+  data-port:           &data-port            null
   worker-multiplier:   &worker-multiplier    0.25
   osd-devices:         &osd-devices          /dev/sdb /dev/vdb
   expected-osd-count:  &expected-osd-count   3

--- a/development/openstack-telemetry-bionic-ussuri/bundle.yaml
+++ b/development/openstack-telemetry-bionic-ussuri/bundle.yaml
@@ -1,6 +1,12 @@
+# Please refer to the OpenStack Charms Deployment Guide for more information.
+# https://docs.openstack.org/project-deploy-guide/charm-deployment-guide
+#
+# NOTE: Please review the value for the configuration option
+#       `bridge-interface-mappings` for the `ovn-chassis` charm (see `data-port` variable).
+
 variables:
   openstack-origin:    &openstack-origin     cloud:bionic-ussuri
-  data-port:           &data-port            br-ex:eno2
+  data-port:           &data-port            null
   worker-multiplier:   &worker-multiplier    0.25
   osd-devices:         &osd-devices          /dev/sdb /dev/vdb
   expected-osd-count:  &expected-osd-count   3

--- a/development/openstack-telemetry-focal-ussuri-ovn/bundle.yaml
+++ b/development/openstack-telemetry-focal-ussuri-ovn/bundle.yaml
@@ -1,12 +1,17 @@
----
+# Please refer to the OpenStack Charms Deployment Guide for more information.
+# https://docs.openstack.org/project-deploy-guide/charm-deployment-guide
+#
+# NOTE: Please review the value for the configuration option
+#       `bridge-interface-mappings` for the `ovn-chassis` charm (see `data-port` variable).
+#       Refer to the [Open Virtual Network (OVN)](https://docs.openstack.org/project-deploy-guide/charm-deployment-guide/latest/app-ovn.html)
+#       section of the [OpenStack Charms Deployment Guide](https://docs.openstack.org/project-deploy-guide/charm-deployment-guide/latest/)
+#       for more information.
+
 local_overlay_enabled: true
 series: focal
-# *** Please refer to the OpenStack Charms Deployment Guide for more        ***
-# *** information.
-# *** https://docs.openstack.org/project-deploy-guide/charm-deployment-guide **
 variables:
   openstack-origin: &openstack-origin distro
-  data-port: &data-port br-ex:eno2
+  data-port: &data-port null
   worker-multiplier: &worker-multiplier 0.25
   osd-devices: &osd-devices /dev/sdb /dev/vdb
   expected-osd-count: &expected-osd-count 3
@@ -417,9 +422,9 @@ applications:
       gui-x: '120'
       gui-y: '1030'
     charm: cs:~openstack-charmers-next/ovn-chassis
-    # *** Please update the `bridge-interface-mappings` to values suitable ***
-    # *** for thehardware used in your deployment.  See the referenced     ***
-    # *** documentation at the top of this file.                           ***
+    # Please update the `bridge-interface-mappings` to values suitable for the
+    # hardware used in your deployment. See the referenced documentation at the
+    # top of this file.
     options:
       ovn-bridge-mappings: physnet1:br-ex
       bridge-interface-mappings: *data-port

--- a/development/openstack-telemetry-focal-victoria/bundle.yaml
+++ b/development/openstack-telemetry-focal-victoria/bundle.yaml
@@ -1,12 +1,17 @@
----
+# Please refer to the OpenStack Charms Deployment Guide for more information.
+# https://docs.openstack.org/project-deploy-guide/charm-deployment-guide
+#
+# NOTE: Please review the value for the configuration option
+#       `bridge-interface-mappings` for the `ovn-chassis` charm (see `data-port` variable).
+#       Refer to the [Open Virtual Network (OVN)](https://docs.openstack.org/project-deploy-guide/charm-deployment-guide/latest/app-ovn.html)
+#       section of the [OpenStack Charms Deployment Guide](https://docs.openstack.org/project-deploy-guide/charm-deployment-guide/latest/)
+#       for more information.
+
 local_overlay_enabled: true
 series: focal
-# *** Please refer to the OpenStack Charms Deployment Guide for more        ***
-# *** information.
-# *** https://docs.openstack.org/project-deploy-guide/charm-deployment-guide **
 variables:
   openstack-origin: &openstack-origin cloud:focal-victoria
-  data-port: &data-port br-ex:eno2
+  data-port: &data-port null
   worker-multiplier: &worker-multiplier 0.25
   osd-devices: &osd-devices /dev/sdb /dev/vdb
   expected-osd-count: &expected-osd-count 3
@@ -423,9 +428,9 @@ applications:
       gui-x: '120'
       gui-y: '1030'
     charm: cs:~openstack-charmers-next/ovn-chassis
-    # *** Please update the `bridge-interface-mappings` to values suitable ***
-    # *** for thehardware used in your deployment.  See the referenced     ***
-    # *** documentation at the top of this file.                           ***
+    # Please update the `bridge-interface-mappings` to values suitable for the
+    # hardware used in your deployment. See the referenced documentation at the
+    # top of this file.
     options:
       ovn-bridge-mappings: physnet1:br-ex
       bridge-interface-mappings: *data-port

--- a/development/openstack-telemetry-focal-wallaby/bundle.yaml
+++ b/development/openstack-telemetry-focal-wallaby/bundle.yaml
@@ -1,12 +1,17 @@
----
+# Please refer to the OpenStack Charms Deployment Guide for more information.
+# https://docs.openstack.org/project-deploy-guide/charm-deployment-guide
+#
+# NOTE: Please review the value for the configuration option
+#       `bridge-interface-mappings` for the `ovn-chassis` charm (see `data-port` variable).
+#       Refer to the [Open Virtual Network (OVN)](https://docs.openstack.org/project-deploy-guide/charm-deployment-guide/latest/app-ovn.html)
+#       section of the [OpenStack Charms Deployment Guide](https://docs.openstack.org/project-deploy-guide/charm-deployment-guide/latest/)
+#       for more information.
+
 local_overlay_enabled: true
 series: focal
-# *** Please refer to the OpenStack Charms Deployment Guide for more        ***
-# *** information.
-# *** https://docs.openstack.org/project-deploy-guide/charm-deployment-guide **
 variables:
   openstack-origin: &openstack-origin cloud:focal-wallaby
-  data-port: &data-port br-ex:eno2
+  data-port: &data-port null
   worker-multiplier: &worker-multiplier 0.25
   osd-devices: &osd-devices /dev/sdb /dev/vdb
   expected-osd-count: &expected-osd-count 3
@@ -423,9 +428,9 @@ applications:
       gui-x: '120'
       gui-y: '1030'
     charm: cs:~openstack-charmers-next/ovn-chassis
-    # *** Please update the `bridge-interface-mappings` to values suitable ***
-    # *** for thehardware used in your deployment.  See the referenced     ***
-    # *** documentation at the top of this file.                           ***
+    # Please update the `bridge-interface-mappings` to values suitable for the
+    # hardware used in your deployment. See the referenced documentation at the
+    # top of this file.
     options:
       ovn-bridge-mappings: physnet1:br-ex
       bridge-interface-mappings: *data-port

--- a/development/openstack-telemetry-focal-xena/bundle.yaml
+++ b/development/openstack-telemetry-focal-xena/bundle.yaml
@@ -1,12 +1,17 @@
----
+# Please refer to the OpenStack Charms Deployment Guide for more information.
+# https://docs.openstack.org/project-deploy-guide/charm-deployment-guide
+#
+# NOTE: Please review the value for the configuration option
+#       `bridge-interface-mappings` for the `ovn-chassis` charm (see `data-port` variable).
+#       Refer to the [Open Virtual Network (OVN)](https://docs.openstack.org/project-deploy-guide/charm-deployment-guide/latest/app-ovn.html)
+#       section of the [OpenStack Charms Deployment Guide](https://docs.openstack.org/project-deploy-guide/charm-deployment-guide/latest/)
+#       for more information.
+
 local_overlay_enabled: true
 series: focal
-# *** Please refer to the OpenStack Charms Deployment Guide for more        ***
-# *** information.
-# *** https://docs.openstack.org/project-deploy-guide/charm-deployment-guide **
 variables:
   openstack-origin: &openstack-origin cloud:focal-xena
-  data-port: &data-port br-ex:eno2
+  data-port: &data-port null
   worker-multiplier: &worker-multiplier 0.25
   osd-devices: &osd-devices /dev/sdb /dev/vdb
   expected-osd-count: &expected-osd-count 3
@@ -423,9 +428,9 @@ applications:
       gui-x: '120'
       gui-y: '1030'
     charm: cs:~openstack-charmers-next/ovn-chassis
-    # *** Please update the `bridge-interface-mappings` to values suitable ***
-    # *** for thehardware used in your deployment.  See the referenced     ***
-    # *** documentation at the top of this file.                           ***
+    # Please update the `bridge-interface-mappings` to values suitable for the
+    # hardware used in your deployment. See the referenced documentation at the
+    # top of this file.
     options:
       ovn-bridge-mappings: physnet1:br-ex
       bridge-interface-mappings: *data-port

--- a/development/openstack-telemetry-groovy-victoria/bundle.yaml
+++ b/development/openstack-telemetry-groovy-victoria/bundle.yaml
@@ -1,12 +1,17 @@
----
+# Please refer to the OpenStack Charms Deployment Guide for more information.
+# https://docs.openstack.org/project-deploy-guide/charm-deployment-guide
+#
+# NOTE: Please review the value for the configuration option
+#       `bridge-interface-mappings` for the `ovn-chassis` charm (see `data-port` variable).
+#       Refer to the [Open Virtual Network (OVN)](https://docs.openstack.org/project-deploy-guide/charm-deployment-guide/latest/app-ovn.html)
+#       section of the [OpenStack Charms Deployment Guide](https://docs.openstack.org/project-deploy-guide/charm-deployment-guide/latest/)
+#       for more information.
+
 local_overlay_enabled: true
 series: groovy
-# *** Please refer to the OpenStack Charms Deployment Guide for more        ***
-# *** information.
-# *** https://docs.openstack.org/project-deploy-guide/charm-deployment-guide **
 variables:
   openstack-origin: &openstack-origin distro
-  data-port: &data-port br-ex:eno2
+  data-port: &data-port null
   worker-multiplier: &worker-multiplier 0.25
   osd-devices: &osd-devices /dev/sdb /dev/vdb
   expected-osd-count: &expected-osd-count 3
@@ -417,9 +422,9 @@ applications:
       gui-x: '120'
       gui-y: '1030'
     charm: cs:~openstack-charmers-next/ovn-chassis
-    # *** Please update the `bridge-interface-mappings` to values suitable ***
-    # *** for thehardware used in your deployment.  See the referenced     ***
-    # *** documentation at the top of this file.                           ***
+    # Please update the `bridge-interface-mappings` to values suitable for the
+    # hardware used in your deployment. See the referenced documentation at the
+    # top of this file.
     options:
       ovn-bridge-mappings: physnet1:br-ex
       bridge-interface-mappings: *data-port

--- a/development/openstack-telemetry-impish-xena/bundle.yaml
+++ b/development/openstack-telemetry-impish-xena/bundle.yaml
@@ -1,12 +1,17 @@
----
+# Please refer to the OpenStack Charms Deployment Guide for more information.
+# https://docs.openstack.org/project-deploy-guide/charm-deployment-guide
+#
+# NOTE: Please review the value for the configuration option
+#       `bridge-interface-mappings` for the `ovn-chassis` charm (see `data-port` variable).
+#       Refer to the [Open Virtual Network (OVN)](https://docs.openstack.org/project-deploy-guide/charm-deployment-guide/latest/app-ovn.html)
+#       section of the [OpenStack Charms Deployment Guide](https://docs.openstack.org/project-deploy-guide/charm-deployment-guide/latest/)
+#       for more information.
+
 local_overlay_enabled: true
 series: impish
-# *** Please refer to the OpenStack Charms Deployment Guide for more        ***
-# *** information.
-# *** https://docs.openstack.org/project-deploy-guide/charm-deployment-guide **
 variables:
   openstack-origin: &openstack-origin distro
-  data-port: &data-port br-ex:eno2
+  data-port: &data-port null
   worker-multiplier: &worker-multiplier 0.25
   osd-devices: &osd-devices /dev/sdb /dev/vdb
   expected-osd-count: &expected-osd-count 3
@@ -423,9 +428,9 @@ applications:
       gui-x: '120'
       gui-y: '1030'
     charm: cs:~openstack-charmers-next/ovn-chassis
-    # *** Please update the `bridge-interface-mappings` to values suitable ***
-    # *** for thehardware used in your deployment.  See the referenced     ***
-    # *** documentation at the top of this file.                           ***
+    # Please update the `bridge-interface-mappings` to values suitable for the
+    # hardware used in your deployment. See the referenced documentation at the
+    # top of this file.
     options:
       ovn-bridge-mappings: physnet1:br-ex
       bridge-interface-mappings: *data-port

--- a/development/overlays/openstack-base-ovn.yaml
+++ b/development/overlays/openstack-base-ovn.yaml
@@ -91,7 +91,7 @@ applications:
       the top of this file.
     options:
       ovn-bridge-mappings: physnet1:br-provider
-      bridge-interface-mappings: br-provider:00:00:5e:00:00:42 br-provider:00:00:5e:00:00:51
+      bridge-interface-mappings: *data-port
   vault:
     charm: cs:~openstack-charmers-next/vault
     num_units: 1

--- a/stable/openstack-base/bundle.yaml
+++ b/stable/openstack-base/bundle.yaml
@@ -1,10 +1,16 @@
 # Please refer to the OpenStack Charms Deployment Guide for more information.
 # https://docs.openstack.org/project-deploy-guide/charm-deployment-guide
+#
+# NOTE: Please review the value for the configuration option
+#       `bridge-interface-mappings` for the `ovn-chassis` charm (see `data-port` variable).
+#       Refer to the [Open Virtual Network (OVN)](https://docs.openstack.org/project-deploy-guide/charm-deployment-guide/latest/app-ovn.html)
+#       section of the [OpenStack Charms Deployment Guide](https://docs.openstack.org/project-deploy-guide/charm-deployment-guide/latest/)
+#       for more information.
 
 series: focal
 variables:
   openstack-origin: &openstack-origin cloud:focal-wallaby
-  data-port: &data-port br-ex:eno2
+  data-port: &data-port null
   worker-multiplier: &worker-multiplier 0.25
   osd-devices: &osd-devices /dev/sdb /dev/vdb
   expected-osd-count: &expected-osd-count 3

--- a/stable/openstack-telemetry/bundle.yaml
+++ b/stable/openstack-telemetry/bundle.yaml
@@ -1,11 +1,17 @@
+# Please refer to the OpenStack Charms Deployment Guide for more information.
+# https://docs.openstack.org/project-deploy-guide/charm-deployment-guide
+#
+# NOTE: Please review the value for the configuration option
+#       `bridge-interface-mappings` for the `ovn-chassis` charm (see `data-port` variable).
+#       Refer to the [Open Virtual Network (OVN)](https://docs.openstack.org/project-deploy-guide/charm-deployment-guide/latest/app-ovn.html)
+#       section of the [OpenStack Charms Deployment Guide](https://docs.openstack.org/project-deploy-guide/charm-deployment-guide/latest/)
+#       for more information.
+
 local_overlay_enabled: true
 series: focal
-# *** Please refer to the OpenStack Charms Deployment Guide for more        ***
-# *** information.
-# *** https://docs.openstack.org/project-deploy-guide/charm-deployment-guide **
 variables:
   openstack-origin: &openstack-origin cloud:focal-victoria
-  data-port: &data-port br-ex:eno2
+  data-port: &data-port null
   worker-multiplier: &worker-multiplier 0.25
   osd-devices: &osd-devices /dev/sdb /dev/vdb
   expected-osd-count: &expected-osd-count 3
@@ -420,9 +426,9 @@ applications:
       gui-x: '120'
       gui-y: '1030'
     charm: cs:ovn-chassis-14
-    # *** Please update the `bridge-interface-mappings` to values suitable ***
-    # *** for thehardware used in your deployment.  See the referenced     ***
-    # *** documentation at the top of this file.                           ***
+    # Please update the `bridge-interface-mappings` to values suitable for the
+    # hardware used in your deployment. See the referenced documentation at the
+    # top of this file.
     options:
       ovn-bridge-mappings: physnet1:br-ex
       bridge-interface-mappings: *data-port

--- a/stable/overlays/openstack-base-ovn.yaml
+++ b/stable/overlays/openstack-base-ovn.yaml
@@ -91,7 +91,7 @@ applications:
       the top of this file.
     options:
       ovn-bridge-mappings: physnet1:br-provider
-      bridge-interface-mappings: br-provider:00:00:5e:00:00:42 br-provider:00:00:5e:00:00:51
+      bridge-interface-mappings: *data-port
   vault:
     charm: cs:vault
     num_units: 1


### PR DESCRIPTION
Since the bridge mappings are environment-specific, they are commented
out so that users can set them on their own.

On a related note, we test these bundles with zaza-openstack-tests, which
will configure the bridge mappings only if the bridge mapping config is not
already set by the bundle or otherwise. [1]

[1] https://github.com/openstack-charmers/zaza-openstack-tests/pull/625