### PR TITLE
Openstack-base README typos fixes

### DIFF
--- a/development/openstack-base-hirsute-wallaby/README.md
+++ b/development/openstack-base-hirsute-wallaby/README.md
@@ -35,7 +35,7 @@ The MAAS cluster must have a minimum of four nodes:
 
   The first disk is used for the node's operating system, and the second is for
   Ceph storage.
-  
+
   The first network interface is used for communication between cloud services
   (East/West traffic), and the second is for network traffic between the cloud
   and all external networks (North/South traffic).
@@ -186,7 +186,7 @@ You'll need to import an image into Glance in order to create instances.
 
 First download a boot image, like Focal amd64:
 
-    curl http://cloud-images.ubuntu.com/focal/current/focal-server-cloudimg-amd64.img
+    curl http://cloud-images.ubuntu.com/focal/current/focal-server-cloudimg-amd64.img \
        --output ~/cloud-images/focal-amd64.img
 
 Now import the image and call it 'focal-amd64':
@@ -201,7 +201,7 @@ way.
 For the ARM 64-bit (arm64) architecture you will need to configure the image to
 boot in UEFI mode:
 
-    curl http://cloud-images.ubuntu.com/focal/current/focal-server-cloudimg-amd64.img
+    curl http://cloud-images.ubuntu.com/focal/current/focal-server-cloudimg-amd64.img \
        --output ~/cloud-images/focal-arm64.img
 
     openstack image create --public --container-format bare \
@@ -239,7 +239,7 @@ router ('provider-router'):
     openstack network create int_net
 
     openstack subnet create --network int_net --dns-nameserver 8.8.8.8 \
-       --gateway 192.168.0.1 --subnet-range 192.168.0/24 \
+       --gateway 192.168.0.1 --subnet-range 192.168.0.0/24 \
        --allocation-pool start=192.168.0.10,end=192.168.0.200 \
        int_subnet
 

--- a/development/openstack-base-impish-xena/README.md
+++ b/development/openstack-base-impish-xena/README.md
@@ -35,7 +35,7 @@ The MAAS cluster must have a minimum of four nodes:
 
   The first disk is used for the node's operating system, and the second is for
   Ceph storage.
-  
+
   The first network interface is used for communication between cloud services
   (East/West traffic), and the second is for network traffic between the cloud
   and all external networks (North/South traffic).
@@ -186,7 +186,7 @@ You'll need to import an image into Glance in order to create instances.
 
 First download a boot image, like Focal amd64:
 
-    curl http://cloud-images.ubuntu.com/focal/current/focal-server-cloudimg-amd64.img
+    curl http://cloud-images.ubuntu.com/focal/current/focal-server-cloudimg-amd64.img \
        --output ~/cloud-images/focal-amd64.img
 
 Now import the image and call it 'focal-amd64':
@@ -201,7 +201,7 @@ way.
 For the ARM 64-bit (arm64) architecture you will need to configure the image to
 boot in UEFI mode:
 
-    curl http://cloud-images.ubuntu.com/focal/current/focal-server-cloudimg-amd64.img
+    curl http://cloud-images.ubuntu.com/focal/current/focal-server-cloudimg-amd64.img \
        --output ~/cloud-images/focal-arm64.img
 
     openstack image create --public --container-format bare \
@@ -239,7 +239,7 @@ router ('provider-router'):
     openstack network create int_net
 
     openstack subnet create --network int_net --dns-nameserver 8.8.8.8 \
-       --gateway 192.168.0.1 --subnet-range 192.168.0/24 \
+       --gateway 192.168.0.1 --subnet-range 192.168.0.0/24 \
        --allocation-pool start=192.168.0.10,end=192.168.0.200 \
        int_subnet
 

--- a/stable/openstack-base/README.md
+++ b/stable/openstack-base/README.md
@@ -32,7 +32,7 @@ The MAAS cluster must have a minimum of four nodes:
 
   The first disk is used for the node's operating system, and the second is for
   Ceph storage.
-  
+
   The first network interface is used for communication between cloud services
   (East/West traffic), and the second is for network traffic between the cloud
   and all external networks (North/South traffic).
@@ -183,7 +183,7 @@ You'll need to import an image into Glance in order to create instances.
 
 First download a boot image, like Focal amd64:
 
-    curl http://cloud-images.ubuntu.com/focal/current/focal-server-cloudimg-amd64.img
+    curl http://cloud-images.ubuntu.com/focal/current/focal-server-cloudimg-amd64.img \
        --output ~/cloud-images/focal-amd64.img
 
 Now import the image and call it 'focal-amd64':
@@ -198,7 +198,7 @@ way.
 For the ARM 64-bit (arm64) architecture you will need to configure the image to
 boot in UEFI mode:
 
-    curl http://cloud-images.ubuntu.com/focal/current/focal-server-cloudimg-amd64.img
+    curl http://cloud-images.ubuntu.com/focal/current/focal-server-cloudimg-amd64.img \
        --output ~/cloud-images/focal-arm64.img
 
     openstack image create --public --container-format bare \
@@ -236,7 +236,7 @@ router ('provider-router'):
     openstack network create int_net
 
     openstack subnet create --network int_net --dns-nameserver 8.8.8.8 \
-       --gateway 192.168.0.1 --subnet-range 192.168.0/24 \
+       --gateway 192.168.0.1 --subnet-range 192.168.0.0/24 \
        --allocation-pool start=192.168.0.10,end=192.168.0.200 \
        int_subnet
 


### PR DESCRIPTION
Changes:
- Added \ at the end of multiline terminal commands for easier use
- fixed subnet-range to be a proper CIDR