### PR TITLE
Align dev virt-overlay to stable one

### DIFF
--- a/development/overlays/openstack-base-virt-overlay.yaml
+++ b/development/overlays/openstack-base-virt-overlay.yaml
@@ -2,39 +2,107 @@ machines: {}
 applications:
   ceph-osd:
     to: []
+    bindings:
+      "": ""
     storage:
       osd-devices: 20GB
-  neutron-gateway:
-    options:
-      data-port:
-    to: []
   ceph-mon:
     to: []
+    bindings:
+      "": ""
   ceph-radosgw:
     to: []
+    bindings:
+      "": ""
   cinder:
     expose: True
     to: []
+    bindings:
+      "": ""
+  cinder-ceph:
+    bindings:
+      "": ""
+  cinder-mysql-router:
+    bindings:
+      "": ""
   glance:
     expose: True
     to: []
+    bindings:
+      "": ""
+  glance-mysql-router:
+    bindings:
+      "": ""
   keystone:
     expose: True
     to: []
-  mysql:
+    bindings:
+      "": ""
+  keystone-mysql-router:
+    bindings:
+      "": ""
+  mysql-innodb-cluster:
     to: []
+    bindings:
+      "": ""
   neutron-api:
     expose: True
     to: []
+    bindings:
+      "": ""
+  neutron-api-plugin-ovn:
+    bindings:
+      "": ""
+  neutron-mysql-router:
+    bindings:
+      "": ""
   nova-cloud-controller:
     expose: True
     to: []
+    bindings:
+      "": ""
   nova-compute:
     annotations:
     to: []
+    constraints: mem=4G
+    bindings:
+      "": ""
+  nova-mysql-router:
+    bindings:
+      "": ""
   openstack-dashboard:
     expose: True
     to: []
+    bindings:
+      "": ""
+  dashboard-mysql-router:
+    bindings:
+      "": ""
+  ovn-central:
+    to: []
+    bindings:
+      "": ""
+  ovn-chassis:
+    bindings:
+      "": ""
+  placement:
+    to: []
+    bindings:
+      "": ""
+  placement-mysql-router:
+    bindings:
+      "": ""
   rabbitmq-server:
     to: []
+    bindings:
+      "": ""
   ntp:
+    bindings:
+      "": ""
+  vault:
+    to: []
+    bindings:
+      "": ""
+  vault-mysql-router:
+    bindings:
+      "": ""


### PR DESCRIPTION
It seems like the stable virt-overlay got improved
over time and the development one got forgotten
along the way.