### PR TITLE
Change default data-port value from null to to-be-set

### DIFF
--- a/development/openstack-base-bionic-stein/bundle.yaml
+++ b/development/openstack-base-bionic-stein/bundle.yaml
@@ -6,7 +6,7 @@
 
 variables:
   openstack-origin:    &openstack-origin     cloud:bionic-stein
-  data-port:           &data-port            null
+  data-port:           &data-port            to-be-set
   worker-multiplier:   &worker-multiplier    0.25
   osd-devices:         &osd-devices          /dev/sdb /dev/vdb
   expected-osd-count:  &expected-osd-count   3

--- a/development/openstack-base-bionic-train/bundle.yaml
+++ b/development/openstack-base-bionic-train/bundle.yaml
@@ -6,7 +6,7 @@
 
 variables:
   openstack-origin:    &openstack-origin     cloud:bionic-train
-  data-port:           &data-port            null
+  data-port:           &data-port            to-be-set
   worker-multiplier:   &worker-multiplier    0.25
   osd-devices:         &osd-devices          /dev/sdb /dev/vdb
   expected-osd-count:  &expected-osd-count   3

--- a/development/openstack-base-bionic-ussuri-ovn/bundle.yaml
+++ b/development/openstack-base-bionic-ussuri-ovn/bundle.yaml
@@ -13,7 +13,7 @@ local_overlay_enabled: true
 series: bionic
 variables:
   openstack-origin:    &openstack-origin     cloud:bionic-ussuri
-  data-port:           &data-port            null
+  data-port:           &data-port            to-be-set
   worker-multiplier:   &worker-multiplier    0.25
   osd-devices:         &osd-devices          /dev/sdb /dev/vdb
   expected-osd-count:  &expected-osd-count   3

--- a/development/openstack-base-bionic-ussuri/bundle.yaml
+++ b/development/openstack-base-bionic-ussuri/bundle.yaml
@@ -6,7 +6,7 @@
 
 variables:
   openstack-origin:    &openstack-origin     cloud:bionic-ussuri
-  data-port:           &data-port            null
+  data-port:           &data-port            to-be-set
   worker-multiplier:   &worker-multiplier    0.25
   osd-devices:         &osd-devices          /dev/sdb /dev/vdb
   expected-osd-count:  &expected-osd-count   3

--- a/development/openstack-base-eoan-train-mysql8-migration/bundle.yaml
+++ b/development/openstack-base-eoan-train-mysql8-migration/bundle.yaml
@@ -13,7 +13,7 @@ local_overlay_enabled: true
 series: eoan
 variables:
   openstack-origin:    &openstack-origin     distro
-  data-port:           &data-port            null
+  data-port:           &data-port            to-be-set
   worker-multiplier:   &worker-multiplier    0.25
   osd-devices:         &osd-devices          /dev/sdb /dev/vdb
   expected-osd-count:  &expected-osd-count   3

--- a/development/openstack-base-eoan-train-mysql8-ovn/bundle.yaml
+++ b/development/openstack-base-eoan-train-mysql8-ovn/bundle.yaml
@@ -13,7 +13,7 @@ local_overlay_enabled: true
 series: eoan
 variables:
   openstack-origin:    &openstack-origin     distro
-  data-port:           &data-port            null
+  data-port:           &data-port            to-be-set
   worker-multiplier:   &worker-multiplier    0.25
   osd-devices:         &osd-devices          /dev/sdb /dev/vdb
   expected-osd-count:  &expected-osd-count   3

--- a/development/openstack-base-eoan-train/bundle.yaml
+++ b/development/openstack-base-eoan-train/bundle.yaml
@@ -6,7 +6,7 @@
 
 variables:
   openstack-origin:    &openstack-origin     distro
-  data-port:           &data-port            null
+  data-port:           &data-port            to-be-set
   worker-multiplier:   &worker-multiplier    0.25
   osd-devices:         &osd-devices          /dev/sdb /dev/vdb
   expected-osd-count:  &expected-osd-count   3

--- a/development/openstack-base-focal-ussuri-ovn/bundle.yaml
+++ b/development/openstack-base-focal-ussuri-ovn/bundle.yaml
@@ -11,7 +11,7 @@ local_overlay_enabled: true
 series: focal
 variables:
   openstack-origin: &openstack-origin distro
-  data-port: &data-port null
+  data-port: &data-port to-be-set
   worker-multiplier: &worker-multiplier 0.25
   osd-devices: &osd-devices /dev/sdb /dev/vdb
   expected-osd-count: &expected-osd-count 3

--- a/development/openstack-base-focal-victoria/bundle.yaml
+++ b/development/openstack-base-focal-victoria/bundle.yaml
@@ -11,7 +11,7 @@ local_overlay_enabled: true
 series: focal
 variables:
   openstack-origin: &openstack-origin cloud:focal-victoria
-  data-port: &data-port null
+  data-port: &data-port to-be-set
   worker-multiplier: &worker-multiplier 0.25
   osd-devices: &osd-devices /dev/sdb /dev/vdb
   expected-osd-count: &expected-osd-count 3

--- a/development/openstack-base-focal-wallaby/bundle.yaml
+++ b/development/openstack-base-focal-wallaby/bundle.yaml
@@ -10,7 +10,7 @@
 series: focal
 variables:
   openstack-origin: &openstack-origin cloud:focal-wallaby
-  data-port: &data-port null
+  data-port: &data-port to-be-set
   worker-multiplier: &worker-multiplier 0.25
   osd-devices: &osd-devices /dev/sdb /dev/vdb
   expected-osd-count: &expected-osd-count 3

--- a/development/openstack-base-focal-xena/bundle.yaml
+++ b/development/openstack-base-focal-xena/bundle.yaml
@@ -10,7 +10,7 @@
 series: focal
 variables:
   openstack-origin: &openstack-origin cloud:focal-xena
-  data-port: &data-port null
+  data-port: &data-port to-be-set
   worker-multiplier: &worker-multiplier 0.25
   osd-devices: &osd-devices /dev/sdb /dev/vdb
   expected-osd-count: &expected-osd-count 3

--- a/development/openstack-base-groovy-victoria/bundle.yaml
+++ b/development/openstack-base-groovy-victoria/bundle.yaml
@@ -11,7 +11,7 @@ local_overlay_enabled: true
 series: groovy
 variables:
   openstack-origin: &openstack-origin distro
-  data-port: &data-port null
+  data-port: &data-port to-be-set
   worker-multiplier: &worker-multiplier 0.25
   osd-devices: &osd-devices /dev/sdb /dev/vdb
   expected-osd-count: &expected-osd-count 3

--- a/development/openstack-base-hirsute-wallaby/bundle.yaml
+++ b/development/openstack-base-hirsute-wallaby/bundle.yaml
@@ -10,7 +10,7 @@
 series: hirsute
 variables:
   openstack-origin: &openstack-origin distro
-  data-port: &data-port null
+  data-port: &data-port to-be-set
   worker-multiplier: &worker-multiplier 0.25
   osd-devices: &osd-devices /dev/sdb /dev/vdb
   expected-osd-count: &expected-osd-count 3

--- a/development/openstack-base-impish-xena/bundle.yaml
+++ b/development/openstack-base-impish-xena/bundle.yaml
@@ -10,7 +10,7 @@
 series: impish
 variables:
   openstack-origin: &openstack-origin distro
-  data-port: &data-port null
+  data-port: &data-port to-be-set
   worker-multiplier: &worker-multiplier 0.25
   osd-devices: &osd-devices /dev/sdb /dev/vdb
   expected-osd-count: &expected-osd-count 3

--- a/development/openstack-converged-networking-focal-ussuri/bundle.yaml
+++ b/development/openstack-converged-networking-focal-ussuri/bundle.yaml
@@ -11,7 +11,7 @@ local_overlay_enabled: true
 series: focal
 variables:
   openstack-origin: &openstack-origin distro-proposed
-  data-port: &data-port null
+  data-port: &data-port to-be-set
   worker-multiplier: &worker-multiplier 0.25
   osd-devices: &osd-devices /dev/sdb /dev/vdb
   expected-osd-count: &expected-osd-count 3

--- a/development/openstack-ha/masakari-mosci.yaml
+++ b/development/openstack-ha/masakari-mosci.yaml
@@ -6,7 +6,7 @@
 
 variables:
   openstack-origin:    &openstack-origin     cloud:bionic-ussuri
-  data-port:           &data-port            null
+  data-port:           &data-port            to-be-set
   worker-multiplier:   &worker-multiplier    0.25
   osd-devices:         &osd-devices          /dev/sdb /dev/vdb
   expected-osd-count:  &expected-osd-count   3

--- a/development/openstack-telemetry-bionic-stein/bundle.yaml
+++ b/development/openstack-telemetry-bionic-stein/bundle.yaml
@@ -6,7 +6,7 @@
 
 variables:
   openstack-origin:    &openstack-origin     cloud:bionic-stein
-  data-port:           &data-port            null
+  data-port:           &data-port            to-be-set
   worker-multiplier:   &worker-multiplier    0.25
   osd-devices:         &osd-devices          /dev/sdb /dev/vdb
   expected-osd-count:  &expected-osd-count   3

--- a/development/openstack-telemetry-bionic-train/bundle.yaml
+++ b/development/openstack-telemetry-bionic-train/bundle.yaml
@@ -6,7 +6,7 @@
 
 variables:
   openstack-origin:    &openstack-origin     cloud:bionic-train
-  data-port:           &data-port            null
+  data-port:           &data-port            to-be-set
   worker-multiplier:   &worker-multiplier    0.25
   osd-devices:         &osd-devices          /dev/sdb /dev/vdb
   expected-osd-count:  &expected-osd-count   3

--- a/development/openstack-telemetry-bionic-ussuri/bundle.yaml
+++ b/development/openstack-telemetry-bionic-ussuri/bundle.yaml
@@ -6,7 +6,7 @@
 
 variables:
   openstack-origin:    &openstack-origin     cloud:bionic-ussuri
-  data-port:           &data-port            null
+  data-port:           &data-port            to-be-set
   worker-multiplier:   &worker-multiplier    0.25
   osd-devices:         &osd-devices          /dev/sdb /dev/vdb
   expected-osd-count:  &expected-osd-count   3

--- a/development/openstack-telemetry-focal-ussuri-ovn/bundle.yaml
+++ b/development/openstack-telemetry-focal-ussuri-ovn/bundle.yaml
@@ -11,7 +11,7 @@ local_overlay_enabled: true
 series: focal
 variables:
   openstack-origin: &openstack-origin distro
-  data-port: &data-port null
+  data-port: &data-port to-be-set
   worker-multiplier: &worker-multiplier 0.25
   osd-devices: &osd-devices /dev/sdb /dev/vdb
   expected-osd-count: &expected-osd-count 3

--- a/development/openstack-telemetry-focal-victoria/bundle.yaml
+++ b/development/openstack-telemetry-focal-victoria/bundle.yaml
@@ -11,7 +11,7 @@ local_overlay_enabled: true
 series: focal
 variables:
   openstack-origin: &openstack-origin cloud:focal-victoria
-  data-port: &data-port null
+  data-port: &data-port to-be-set
   worker-multiplier: &worker-multiplier 0.25
   osd-devices: &osd-devices /dev/sdb /dev/vdb
   expected-osd-count: &expected-osd-count 3

--- a/development/openstack-telemetry-focal-wallaby/bundle.yaml
+++ b/development/openstack-telemetry-focal-wallaby/bundle.yaml
@@ -11,7 +11,7 @@ local_overlay_enabled: true
 series: focal
 variables:
   openstack-origin: &openstack-origin cloud:focal-wallaby
-  data-port: &data-port null
+  data-port: &data-port to-be-set
   worker-multiplier: &worker-multiplier 0.25
   osd-devices: &osd-devices /dev/sdb /dev/vdb
   expected-osd-count: &expected-osd-count 3

--- a/development/openstack-telemetry-focal-xena/bundle.yaml
+++ b/development/openstack-telemetry-focal-xena/bundle.yaml
@@ -11,7 +11,7 @@ local_overlay_enabled: true
 series: focal
 variables:
   openstack-origin: &openstack-origin cloud:focal-xena
-  data-port: &data-port null
+  data-port: &data-port to-be-set
   worker-multiplier: &worker-multiplier 0.25
   osd-devices: &osd-devices /dev/sdb /dev/vdb
   expected-osd-count: &expected-osd-count 3

--- a/development/openstack-telemetry-groovy-victoria/bundle.yaml
+++ b/development/openstack-telemetry-groovy-victoria/bundle.yaml
@@ -11,7 +11,7 @@ local_overlay_enabled: true
 series: groovy
 variables:
   openstack-origin: &openstack-origin distro
-  data-port: &data-port null
+  data-port: &data-port to-be-set
   worker-multiplier: &worker-multiplier 0.25
   osd-devices: &osd-devices /dev/sdb /dev/vdb
   expected-osd-count: &expected-osd-count 3

--- a/development/openstack-telemetry-impish-xena/bundle.yaml
+++ b/development/openstack-telemetry-impish-xena/bundle.yaml
@@ -11,7 +11,7 @@ local_overlay_enabled: true
 series: impish
 variables:
   openstack-origin: &openstack-origin distro
-  data-port: &data-port null
+  data-port: &data-port to-be-set
   worker-multiplier: &worker-multiplier 0.25
   osd-devices: &osd-devices /dev/sdb /dev/vdb
   expected-osd-count: &expected-osd-count 3

--- a/stable/openstack-base/bundle.yaml
+++ b/stable/openstack-base/bundle.yaml
@@ -10,7 +10,7 @@
 series: focal
 variables:
   openstack-origin: &openstack-origin cloud:focal-xena
-  data-port:
+  data-port: &data-port to-be-set
   worker-multiplier: &worker-multiplier 0.25
   osd-devices: &osd-devices /dev/sdb /dev/vdb
   expected-osd-count: &expected-osd-count 3
@@ -365,7 +365,7 @@ applications:
     # top of this file.
     options:
       ovn-bridge-mappings: physnet1:br-ex
-      bridge-interface-mappings:
+      bridge-interface-mappings: *data-port
   vault-mysql-router:
     annotations:
       gui-x: '1535'

--- a/stable/openstack-telemetry/bundle.yaml
+++ b/stable/openstack-telemetry/bundle.yaml
@@ -11,7 +11,7 @@ local_overlay_enabled: true
 series: focal
 variables:
   openstack-origin: &openstack-origin cloud:focal-xena
-  data-port:
+  data-port: &data-port to-be-set
   worker-multiplier: &worker-multiplier 0.25
   osd-devices: &osd-devices /dev/sdb /dev/vdb
   expected-osd-count: &expected-osd-count 3
@@ -433,7 +433,7 @@ applications:
     # top of this file.
     options:
       ovn-bridge-mappings: physnet1:br-ex
-      bridge-interface-mappings:
+      bridge-interface-mappings: *data-port
   vault-mysql-router:
     annotations:
       gui-x: '1535'


### PR DESCRIPTION
`null` is a YAML keyword that leads to
tools/update-bundle-version removing the data-port
entirely from the stable bundles.