### PR TITLE
Use charmhub (ch:) instead of charm store (cs:) in Yoga

### DIFF
--- a/development/ceph-base-jammy-quincy/bundle.yaml
+++ b/development/ceph-base-jammy-quincy/bundle.yaml
@@ -9,12 +9,13 @@ relations:
 - - ceph-osd:mon
   - ceph-mon:osd
 series: jammy
-services:
+applications:
   ceph-mon:
     annotations:
       gui-x: '750'
       gui-y: '500'
-    charm: cs:~openstack-charmers-next/ceph-mon
+    charm: ch:ceph-mon
+    channel: quincy/edge
     num_units: 3
     options:
       expected-osd-count: 3
@@ -27,7 +28,8 @@ services:
     annotations:
       gui-x: '1000'
       gui-y: '500'
-    charm: cs:~openstack-charmers-next/ceph-osd
+    charm: ch:ceph-osd
+    channel: quincy/edge
     num_units: 3
     options:
       osd-devices: /dev/sdb

--- a/development/openstack-base-focal-yoga/bundle.yaml
+++ b/development/openstack-base-focal-yoga/bundle.yaml
@@ -143,7 +143,7 @@ applications:
     annotations:
       gui-x: '790'
       gui-y: '1540'
-    charm: cs:~openstack-charmers-next/ceph-mon
+    charm: ch:ceph-mon
     num_units: 3
     options:
       expected-osd-count: *expected-osd-count
@@ -153,11 +153,12 @@ applications:
     - lxd:0
     - lxd:1
     - lxd:2
+    channel: quincy/edge
   ceph-osd:
     annotations:
       gui-x: '1065'
       gui-y: '1540'
-    charm: cs:~openstack-charmers-next/ceph-osd
+    charm: ch:ceph-osd
     num_units: 3
     options:
       osd-devices: *osd-devices
@@ -166,26 +167,29 @@ applications:
     - '0'
     - '1'
     - '2'
+    channel: quincy/edge
   ceph-radosgw:
     annotations:
       gui-x: '850'
       gui-y: '900'
-    charm: cs:~openstack-charmers-next/ceph-radosgw
+    charm: ch:ceph-radosgw
     num_units: 1
     options:
       source: *openstack-origin
     to:
     - lxd:0
+    channel: quincy/edge
   cinder-mysql-router:
     annotations:
       gui-x: '900'
       gui-y: '1400'
-    charm: cs:~openstack-charmers-next/mysql-router
+    charm: ch:mysql-router
+    channel: 8.0.19/edge
   cinder:
     annotations:
       gui-x: '980'
       gui-y: '1270'
-    charm: cs:~openstack-charmers-next/cinder
+    charm: ch:cinder
     num_units: 1
     options:
       block-device: None
@@ -194,59 +198,67 @@ applications:
       openstack-origin: *openstack-origin
     to:
     - lxd:1
+    channel: yoga/edge
   cinder-ceph:
     annotations:
       gui-x: '1120'
       gui-y: '1400'
-    charm: cs:~openstack-charmers-next/cinder-ceph
+    charm: ch:cinder-ceph
     num_units: 0
+    channel: yoga/edge
   glance-mysql-router:
     annotations:
       gui-x: '-290'
       gui-y: '1400'
-    charm: cs:~openstack-charmers-next/mysql-router
+    charm: ch:mysql-router
+    channel: 8.0.19/edge
   glance:
     annotations:
       gui-x: '-230'
       gui-y: '1270'
-    charm: cs:~openstack-charmers-next/glance
+    charm: ch:glance
     num_units: 1
     options:
       worker-multiplier: *worker-multiplier
       openstack-origin: *openstack-origin
     to:
     - lxd:2
+    channel: yoga/edge
   keystone-mysql-router:
     annotations:
       gui-x: '230'
       gui-y: '1400'
-    charm: cs:~openstack-charmers-next/mysql-router
+    charm: ch:mysql-router
+    channel: 8.0.19/edge
   keystone:
     annotations:
       gui-x: '300'
       gui-y: '1270'
-    charm: cs:~openstack-charmers-next/keystone
+    charm: ch:keystone
     num_units: 1
     options:
       worker-multiplier: *worker-multiplier
       openstack-origin: *openstack-origin
     to:
     - lxd:0
+    channel: yoga/edge
   neutron-mysql-router:
     annotations:
       gui-x: '505'
       gui-y: '1385'
-    charm: cs:~openstack-charmers-next/mysql-router
+    charm: ch:mysql-router
+    channel: 8.0.19/edge
   neutron-api-plugin-ovn:
     annotations:
       gui-x: '690'
       gui-y: '1385'
-    charm: cs:~openstack-charmers-next/neutron-api-plugin-ovn
+    charm: ch:neutron-api-plugin-ovn
+    channel: yoga/edge
   neutron-api:
     annotations:
       gui-x: '580'
       gui-y: '1270'
-    charm: cs:~openstack-charmers-next/neutron-api
+    charm: ch:neutron-api
     num_units: 1
     options:
       neutron-security-groups: true
@@ -255,32 +267,36 @@ applications:
       openstack-origin: *openstack-origin
     to:
     - lxd:1
+    channel: yoga/edge
   placement-mysql-router:
     annotations:
       gui-x: '1320'
       gui-y: '1385'
-    charm: cs:~openstack-charmers-next/mysql-router
+    charm: ch:mysql-router
+    channel: 8.0.19/edge
   placement:
     annotations:
       gui-x: '1320'
       gui-y: '1270'
-    charm: cs:~openstack-charmers-next/placement
+    charm: ch:placement
     num_units: 1
     options:
       worker-multiplier: *worker-multiplier
       openstack-origin: *openstack-origin
     to:
     - lxd:2
+    channel: yoga/edge
   nova-mysql-router:
     annotations:
       gui-x: '-30'
       gui-y: '1385'
-    charm: cs:~openstack-charmers-next/mysql-router
+    charm: ch:mysql-router
+    channel: 8.0.19/edge
   nova-cloud-controller:
     annotations:
       gui-x: '35'
       gui-y: '1270'
-    charm: cs:~openstack-charmers-next/nova-cloud-controller
+    charm: ch:nova-cloud-controller
     num_units: 1
     options:
       network-manager: Neutron
@@ -288,11 +304,12 @@ applications:
       openstack-origin: *openstack-origin
     to:
     - lxd:0
+    channel: yoga/edge
   nova-compute:
     annotations:
       gui-x: '190'
       gui-y: '890'
-    charm: cs:~openstack-charmers-next/nova-compute
+    charm: ch:nova-compute
     num_units: 3
     options:
       config-flags: default_ephemeral_format=ext4
@@ -304,50 +321,55 @@ applications:
     - '0'
     - '1'
     - '2'
+    channel: yoga/edge
   ntp:
     annotations:
       gui-x: '315'
       gui-y: '1030'
-    charm: cs:ntp
+    charm: ch:ntp
     num_units: 0
   dashboard-mysql-router:
     annotations:
       gui-x: '510'
       gui-y: '1030'
-    charm: cs:~openstack-charmers-next/mysql-router
+    charm: ch:mysql-router
+    channel: 8.0.19/edge
   openstack-dashboard:
     annotations:
       gui-x: '585'
       gui-y: '900'
-    charm: cs:~openstack-charmers-next/openstack-dashboard
+    charm: ch:openstack-dashboard
     num_units: 1
     options:
       openstack-origin: *openstack-origin
     to:
     - lxd:1
+    channel: yoga/edge
   rabbitmq-server:
     annotations:
       gui-x: '300'
       gui-y: '1550'
-    charm: cs:~openstack-charmers-next/rabbitmq-server
+    charm: ch:rabbitmq-server
     num_units: 1
     to:
     - lxd:2
+    channel: 3.9/edge
   mysql-innodb-cluster:
     annotations:
       gui-x: '535'
       gui-y: '1550'
-    charm: cs:~openstack-charmers-next/mysql-innodb-cluster
+    charm: ch:mysql-innodb-cluster
     num_units: 3
     to:
     - lxd:0
     - lxd:1
     - lxd:2
+    channel: 8.0.19/edge
   ovn-central:
     annotations:
       gui-x: '70'
       gui-y: '1550'
-    charm: cs:~openstack-charmers-next/ovn-central
+    charm: ch:ovn-central
     num_units: 3
     options:
       source: *openstack-origin
@@ -355,27 +377,31 @@ applications:
     - lxd:0
     - lxd:1
     - lxd:2
+    channel: 22.03/edge
   ovn-chassis:
     annotations:
       gui-x: '120'
       gui-y: '1030'
-    charm: cs:~openstack-charmers-next/ovn-chassis
+    charm: ch:ovn-chassis
     # Please update the `bridge-interface-mappings` to values suitable for the
     # hardware used in your deployment. See the referenced documentation at the
     # top of this file.
     options:
       ovn-bridge-mappings: physnet1:br-ex
       bridge-interface-mappings: *data-port
+    channel: 22.03/edge
   vault-mysql-router:
     annotations:
       gui-x: '1535'
       gui-y: '1560'
-    charm: cs:~openstack-charmers-next/mysql-router
+    charm: ch:mysql-router
+    channel: 8.0.19/edge
   vault:
     annotations:
       gui-x: '1610'
       gui-y: '1430'
-    charm: cs:vault
+    charm: ch:vault
+    channel: 1.7/edge
     num_units: 1
     to:
     - lxd:0

--- a/development/openstack-base-jammy-yoga/bundle.yaml
+++ b/development/openstack-base-jammy-yoga/bundle.yaml
@@ -1,3 +1,5 @@
+local_overlay_enabled: False
+
 # Please refer to the OpenStack Charms Deployment Guide for more information.
 # https://docs.openstack.org/project-deploy-guide/charm-deployment-guide
 #
@@ -143,7 +145,7 @@ applications:
     annotations:
       gui-x: '790'
       gui-y: '1540'
-    charm: cs:~openstack-charmers-next/ceph-mon
+    charm: ch:ceph-mon
     num_units: 3
     options:
       expected-osd-count: *expected-osd-count
@@ -153,11 +155,12 @@ applications:
     - lxd:0
     - lxd:1
     - lxd:2
+    channel: quincy/edge
   ceph-osd:
     annotations:
       gui-x: '1065'
       gui-y: '1540'
-    charm: cs:~openstack-charmers-next/ceph-osd
+    charm: ch:ceph-osd
     num_units: 3
     options:
       osd-devices: *osd-devices
@@ -166,26 +169,29 @@ applications:
     - '0'
     - '1'
     - '2'
+    channel: quincy/edge
   ceph-radosgw:
     annotations:
       gui-x: '850'
       gui-y: '900'
-    charm: cs:~openstack-charmers-next/ceph-radosgw
+    charm: ch:ceph-radosgw
     num_units: 1
     options:
       source: *openstack-origin
     to:
     - lxd:0
+    channel: quincy/edge
   cinder-mysql-router:
     annotations:
       gui-x: '900'
       gui-y: '1400'
-    charm: cs:~openstack-charmers-next/mysql-router
+    charm: ch:mysql-router
+    channel: 8.0.19/edge
   cinder:
     annotations:
       gui-x: '980'
       gui-y: '1270'
-    charm: cs:~openstack-charmers-next/cinder
+    charm: ch:cinder
     num_units: 1
     options:
       block-device: None
@@ -194,59 +200,67 @@ applications:
       openstack-origin: *openstack-origin
     to:
     - lxd:1
+    channel: yoga/edge
   cinder-ceph:
     annotations:
       gui-x: '1120'
       gui-y: '1400'
-    charm: cs:~openstack-charmers-next/cinder-ceph
+    charm: ch:cinder-ceph
     num_units: 0
+    channel: yoga/edge
   glance-mysql-router:
     annotations:
       gui-x: '-290'
       gui-y: '1400'
-    charm: cs:~openstack-charmers-next/mysql-router
+    charm: ch:mysql-router
+    channel: 8.0.19/edge
   glance:
     annotations:
       gui-x: '-230'
       gui-y: '1270'
-    charm: cs:~openstack-charmers-next/glance
+    charm: ch:glance
     num_units: 1
     options:
       worker-multiplier: *worker-multiplier
       openstack-origin: *openstack-origin
     to:
     - lxd:2
+    channel: yoga/edge
   keystone-mysql-router:
     annotations:
       gui-x: '230'
       gui-y: '1400'
-    charm: cs:~openstack-charmers-next/mysql-router
+    charm: ch:mysql-router
+    channel: 8.0.19/edge
   keystone:
     annotations:
       gui-x: '300'
       gui-y: '1270'
-    charm: cs:~openstack-charmers-next/keystone
+    charm: ch:keystone
     num_units: 1
     options:
       worker-multiplier: *worker-multiplier
       openstack-origin: *openstack-origin
     to:
     - lxd:0
+    channel: yoga/edge
   neutron-mysql-router:
     annotations:
       gui-x: '505'
       gui-y: '1385'
-    charm: cs:~openstack-charmers-next/mysql-router
+    charm: ch:mysql-router
+    channel: 8.0.19/edge
   neutron-api-plugin-ovn:
     annotations:
       gui-x: '690'
       gui-y: '1385'
-    charm: cs:~openstack-charmers-next/neutron-api-plugin-ovn
+    charm: ch:neutron-api-plugin-ovn
+    channel: yoga/edge
   neutron-api:
     annotations:
       gui-x: '580'
       gui-y: '1270'
-    charm: cs:~openstack-charmers-next/neutron-api
+    charm: ch:neutron-api
     num_units: 1
     options:
       neutron-security-groups: true
@@ -255,32 +269,36 @@ applications:
       openstack-origin: *openstack-origin
     to:
     - lxd:1
+    channel: yoga/edge
   placement-mysql-router:
     annotations:
       gui-x: '1320'
       gui-y: '1385'
-    charm: cs:~openstack-charmers-next/mysql-router
+    charm: ch:mysql-router
+    channel: 8.0.19/edge
   placement:
     annotations:
       gui-x: '1320'
       gui-y: '1270'
-    charm: cs:~openstack-charmers-next/placement
+    charm: ch:placement
     num_units: 1
     options:
       worker-multiplier: *worker-multiplier
       openstack-origin: *openstack-origin
     to:
     - lxd:2
+    channel: yoga/edge
   nova-mysql-router:
     annotations:
       gui-x: '-30'
       gui-y: '1385'
-    charm: cs:~openstack-charmers-next/mysql-router
+    charm: ch:mysql-router
+    channel: 8.0.19/edge
   nova-cloud-controller:
     annotations:
       gui-x: '35'
       gui-y: '1270'
-    charm: cs:~openstack-charmers-next/nova-cloud-controller
+    charm: ch:nova-cloud-controller
     num_units: 1
     options:
       network-manager: Neutron
@@ -288,11 +306,12 @@ applications:
       openstack-origin: *openstack-origin
     to:
     - lxd:0
+    channel: yoga/edge
   nova-compute:
     annotations:
       gui-x: '190'
       gui-y: '890'
-    charm: cs:~openstack-charmers-next/nova-compute
+    charm: ch:nova-compute
     num_units: 3
     options:
       config-flags: default_ephemeral_format=ext4
@@ -304,50 +323,55 @@ applications:
     - '0'
     - '1'
     - '2'
+    channel: yoga/edge
   ntp:
     annotations:
       gui-x: '315'
       gui-y: '1030'
-    charm: cs:ntp
+    charm: ch:ntp
     num_units: 0
   dashboard-mysql-router:
     annotations:
       gui-x: '510'
       gui-y: '1030'
-    charm: cs:~openstack-charmers-next/mysql-router
+    charm: ch:mysql-router
+    channel: 8.0.19/edge
   openstack-dashboard:
     annotations:
       gui-x: '585'
       gui-y: '900'
-    charm: cs:~openstack-charmers-next/openstack-dashboard
+    charm: ch:openstack-dashboard
     num_units: 1
     options:
       openstack-origin: *openstack-origin
     to:
     - lxd:1
+    channel: yoga/edge
   rabbitmq-server:
     annotations:
       gui-x: '300'
       gui-y: '1550'
-    charm: cs:~openstack-charmers-next/rabbitmq-server
+    charm: ch:rabbitmq-server
     num_units: 1
     to:
     - lxd:2
+    channel: 3.9/edge
   mysql-innodb-cluster:
     annotations:
       gui-x: '535'
       gui-y: '1550'
-    charm: cs:~openstack-charmers-next/mysql-innodb-cluster
+    charm: ch:mysql-innodb-cluster
     num_units: 3
     to:
     - lxd:0
     - lxd:1
     - lxd:2
+    channel: 8.0.19/edge
   ovn-central:
     annotations:
       gui-x: '70'
       gui-y: '1550'
-    charm: cs:~openstack-charmers-next/ovn-central
+    charm: ch:ovn-central
     num_units: 3
     options:
       source: *openstack-origin
@@ -355,27 +379,31 @@ applications:
     - lxd:0
     - lxd:1
     - lxd:2
+    channel: yoga/edge
   ovn-chassis:
     annotations:
       gui-x: '120'
       gui-y: '1030'
-    charm: cs:~openstack-charmers-next/ovn-chassis
+    charm: ch:ovn-chassis
     # Please update the `bridge-interface-mappings` to values suitable for the
     # hardware used in your deployment. See the referenced documentation at the
     # top of this file.
     options:
       ovn-bridge-mappings: physnet1:br-ex
       bridge-interface-mappings: *data-port
+    channel: yoga/edge
   vault-mysql-router:
     annotations:
       gui-x: '1535'
       gui-y: '1560'
-    charm: cs:~openstack-charmers-next/mysql-router
+    charm: ch:mysql-router
+    channel: 8.0.19/edge
   vault:
     annotations:
       gui-x: '1610'
       gui-y: '1430'
-    charm: cs:vault
+    charm: ch:vault
+    channel: 1.7/edge
     num_units: 1
     to:
     - lxd:0

--- a/development/openstack-telemetry-focal-yoga/bundle.yaml
+++ b/development/openstack-telemetry-focal-yoga/bundle.yaml
@@ -183,35 +183,39 @@ applications:
     annotations:
       gui-x: '1500'
       gui-y: '0'
-    charm: cs:~openstack-charmers-next/aodh
+    charm: ch:aodh
     num_units: 1
     options:
       openstack-origin: *openstack-origin
     to:
     - lxd:0
+    channel: yoga/edge
   aodh-mysql-router:
-    charm: cs:~openstack-charmers-next/mysql-router
+    charm: ch:mysql-router
+    channel: 8.0.19/edge
   ceilometer:
     annotations:
       gui-x: '1250'
       gui-y: '0'
-    charm: cs:~openstack-charmers-next/ceilometer
+    charm: ch:ceilometer
     num_units: 1
     options:
       openstack-origin: *openstack-origin
     to:
     - lxd:2
+    channel: yoga/edge
   ceilometer-agent:
     annotations:
       gui-x: '1250'
       gui-y: '500'
-    charm: cs:~openstack-charmers-next/ceilometer-agent
+    charm: ch:ceilometer-agent
+    channel: yoga/edge
     num_units: 0
   ceph-mon:
     annotations:
       gui-x: '790'
       gui-y: '1540'
-    charm: cs:~openstack-charmers-next/ceph-mon
+    charm: ch:ceph-mon
     num_units: 3
     options:
       expected-osd-count: *expected-osd-count
@@ -221,11 +225,12 @@ applications:
     - lxd:0
     - lxd:1
     - lxd:2
+    channel: quincy/edge
   ceph-osd:
     annotations:
       gui-x: '1065'
       gui-y: '1540'
-    charm: cs:~openstack-charmers-next/ceph-osd
+    charm: ch:ceph-osd
     num_units: 3
     options:
       osd-devices: *osd-devices
@@ -234,26 +239,29 @@ applications:
     - '0'
     - '1'
     - '2'
+    channel: quincy/edge
   ceph-radosgw:
     annotations:
       gui-x: '850'
       gui-y: '900'
-    charm: cs:~openstack-charmers-next/ceph-radosgw
+    charm: ch:ceph-radosgw
     num_units: 1
     options:
       source: *openstack-origin
     to:
     - lxd:0
+    channel: quincy/edge
   cinder-mysql-router:
     annotations:
       gui-x: '900'
       gui-y: '1400'
-    charm: cs:~openstack-charmers-next/mysql-router
+    charm: ch:mysql-router
+    channel: 8.0.19/edge
   cinder:
     annotations:
       gui-x: '980'
       gui-y: '1270'
-    charm: cs:~openstack-charmers-next/cinder
+    charm: ch:cinder
     num_units: 1
     options:
       block-device: None
@@ -262,59 +270,67 @@ applications:
       openstack-origin: *openstack-origin
     to:
     - lxd:1
+    channel: yoga/edge
   cinder-ceph:
     annotations:
       gui-x: '1120'
       gui-y: '1400'
-    charm: cs:~openstack-charmers-next/cinder-ceph
+    charm: ch:cinder-ceph
     num_units: 0
+    channel: yoga/edge
   glance-mysql-router:
     annotations:
       gui-x: '-290'
       gui-y: '1400'
-    charm: cs:~openstack-charmers-next/mysql-router
+    charm: ch:mysql-router
+    channel: 8.0.19/edge
   glance:
     annotations:
       gui-x: '-230'
       gui-y: '1270'
-    charm: cs:~openstack-charmers-next/glance
+    charm: ch:glance
     num_units: 1
     options:
       worker-multiplier: *worker-multiplier
       openstack-origin: *openstack-origin
     to:
     - lxd:2
+    channel: yoga/edge
   keystone-mysql-router:
     annotations:
       gui-x: '230'
       gui-y: '1400'
-    charm: cs:~openstack-charmers-next/mysql-router
+    charm: ch:mysql-router
+    channel: 8.0.19/edge
   keystone:
     annotations:
       gui-x: '300'
       gui-y: '1270'
-    charm: cs:~openstack-charmers-next/keystone
+    charm: ch:keystone
     num_units: 1
     options:
       worker-multiplier: *worker-multiplier
       openstack-origin: *openstack-origin
     to:
     - lxd:0
+    channel: yoga/edge
   neutron-mysql-router:
     annotations:
       gui-x: '505'
       gui-y: '1385'
-    charm: cs:~openstack-charmers-next/mysql-router
+    charm: ch:mysql-router
+    channel: 8.0.19/edge
   neutron-api-plugin-ovn:
     annotations:
       gui-x: '690'
       gui-y: '1385'
-    charm: cs:~openstack-charmers-next/neutron-api-plugin-ovn
+    charm: ch:neutron-api-plugin-ovn
+    channel: yoga/edge
   neutron-api:
     annotations:
       gui-x: '580'
       gui-y: '1270'
-    charm: cs:~openstack-charmers-next/neutron-api
+    charm: ch:neutron-api
     num_units: 1
     options:
       neutron-security-groups: true
@@ -323,32 +339,36 @@ applications:
       openstack-origin: *openstack-origin
     to:
     - lxd:1
+    channel: yoga/edge
   placement-mysql-router:
     annotations:
       gui-x: '1320'
       gui-y: '1385'
-    charm: cs:~openstack-charmers-next/mysql-router
+    charm: ch:mysql-router
+    channel: 8.0.19/edge
   placement:
     annotations:
       gui-x: '1320'
       gui-y: '1270'
-    charm: cs:~openstack-charmers-next/placement
+    charm: ch:placement
     num_units: 1
     options:
       worker-multiplier: *worker-multiplier
       openstack-origin: *openstack-origin
     to:
     - lxd:2
+    channel: yoga/edge
   nova-mysql-router:
     annotations:
       gui-x: '-30'
       gui-y: '1385'
-    charm: cs:~openstack-charmers-next/mysql-router
+    charm: ch:mysql-router
+    channel: 8.0.19/edge
   nova-cloud-controller:
     annotations:
       gui-x: '35'
       gui-y: '1270'
-    charm: cs:~openstack-charmers-next/nova-cloud-controller
+    charm: ch:nova-cloud-controller
     num_units: 1
     options:
       network-manager: Neutron
@@ -356,11 +376,12 @@ applications:
       openstack-origin: *openstack-origin
     to:
     - lxd:0
+    channel: yoga/edge
   nova-compute:
     annotations:
       gui-x: '190'
       gui-y: '890'
-    charm: cs:~openstack-charmers-next/nova-compute
+    charm: ch:nova-compute
     num_units: 3
     options:
       config-flags: default_ephemeral_format=ext4
@@ -372,50 +393,55 @@ applications:
     - '0'
     - '1'
     - '2'
+    channel: yoga/edge
   ntp:
     annotations:
       gui-x: '315'
       gui-y: '1030'
-    charm: cs:ntp
+    charm: ch:ntp
     num_units: 0
   dashboard-mysql-router:
     annotations:
       gui-x: '510'
       gui-y: '1030'
-    charm: cs:~openstack-charmers-next/mysql-router
+    charm: ch:mysql-router
+    channel: 8.0.19/edge
   openstack-dashboard:
     annotations:
       gui-x: '585'
       gui-y: '900'
-    charm: cs:~openstack-charmers-next/openstack-dashboard
+    charm: ch:openstack-dashboard
     num_units: 1
     options:
       openstack-origin: *openstack-origin
     to:
     - lxd:1
+    channel: yoga/edge
   rabbitmq-server:
     annotations:
       gui-x: '300'
       gui-y: '1550'
-    charm: cs:~openstack-charmers-next/rabbitmq-server
+    charm: ch:rabbitmq-server
     num_units: 1
     to:
     - lxd:2
+    channel: 3.9/edge
   mysql-innodb-cluster:
     annotations:
       gui-x: '535'
       gui-y: '1550'
-    charm: cs:~openstack-charmers-next/mysql-innodb-cluster
+    charm: ch:mysql-innodb-cluster
     num_units: 3
     to:
     - lxd:0
     - lxd:1
     - lxd:2
+    channel: 8.0.19/edge
   ovn-central:
     annotations:
       gui-x: '70'
       gui-y: '1550'
-    charm: cs:~openstack-charmers-next/ovn-central
+    charm: ch:ovn-central
     num_units: 3
     options:
       source: *openstack-origin
@@ -423,27 +449,31 @@ applications:
     - lxd:0
     - lxd:1
     - lxd:2
+    channel: 22.03/edge
   ovn-chassis:
     annotations:
       gui-x: '120'
       gui-y: '1030'
-    charm: cs:~openstack-charmers-next/ovn-chassis
+    charm: ch:ovn-chassis
     # Please update the `bridge-interface-mappings` to values suitable for the
     # hardware used in your deployment. See the referenced documentation at the
     # top of this file.
     options:
       ovn-bridge-mappings: physnet1:br-ex
       bridge-interface-mappings: *data-port
+    channel: 22.03/edge
   vault-mysql-router:
     annotations:
       gui-x: '1535'
       gui-y: '1560'
-    charm: cs:~openstack-charmers-next/mysql-router
+    charm: ch:mysql-router
+    channel: 8.0.19/edge
   vault:
     annotations:
       gui-x: '1610'
       gui-y: '1430'
-    charm: cs:vault
+    charm: ch:vault
+    channel: 1.7/edge
     num_units: 1
     to:
     - lxd:0
@@ -452,19 +482,21 @@ applications:
       gui-x: '1500'
       gui-y: '250'
     num_units: 1
-    charm: cs:~openstack-charmers-next/gnocchi
+    charm: ch:gnocchi
     options:
       openstack-origin: *openstack-origin
     to:
     - lxd:1
+    channel: yoga/edge
   gnocchi-mysql-router:
-    charm: cs:~openstack-charmers-next/mysql-router
+    charm: ch:mysql-router
+    channel: 8.0.19/edge
   memcached:
     series: bionic
     annotations:
       gui-x: '1500'
       gui-y: '500'
     num_units: 1
-    charm: cs:memcached
+    charm: ch:memcached
     to:
     - lxd:2

--- a/development/openstack-telemetry-jammy-yoga/bundle.yaml
+++ b/development/openstack-telemetry-jammy-yoga/bundle.yaml
@@ -183,35 +183,39 @@ applications:
     annotations:
       gui-x: '1500'
       gui-y: '0'
-    charm: cs:~openstack-charmers-next/aodh
+    charm: ch:aodh
     num_units: 1
     options:
       openstack-origin: *openstack-origin
     to:
     - lxd:0
+    channel: yoga/edge
   aodh-mysql-router:
-    charm: cs:~openstack-charmers-next/mysql-router
+    charm: ch:mysql-router
+    channel: 8.0.19/edge
   ceilometer:
     annotations:
       gui-x: '1250'
       gui-y: '0'
-    charm: cs:~openstack-charmers-next/ceilometer
+    charm: ch:ceilometer
     num_units: 1
     options:
       openstack-origin: *openstack-origin
     to:
     - lxd:2
+    channel: yoga/edge
   ceilometer-agent:
     annotations:
       gui-x: '1250'
       gui-y: '500'
-    charm: cs:~openstack-charmers-next/ceilometer-agent
+    charm: ch:ceilometer-agent
     num_units: 0
+    channel: yoga/edge
   ceph-mon:
     annotations:
       gui-x: '790'
       gui-y: '1540'
-    charm: cs:~openstack-charmers-next/ceph-mon
+    charm: ch:ceph-mon
     num_units: 3
     options:
       expected-osd-count: *expected-osd-count
@@ -221,11 +225,12 @@ applications:
     - lxd:0
     - lxd:1
     - lxd:2
+    channel: quincy/edge
   ceph-osd:
     annotations:
       gui-x: '1065'
       gui-y: '1540'
-    charm: cs:~openstack-charmers-next/ceph-osd
+    charm: ch:ceph-osd
     num_units: 3
     options:
       osd-devices: *osd-devices
@@ -234,26 +239,29 @@ applications:
     - '0'
     - '1'
     - '2'
+    channel: quincy/edge
   ceph-radosgw:
     annotations:
       gui-x: '850'
       gui-y: '900'
-    charm: cs:~openstack-charmers-next/ceph-radosgw
+    charm: ch:ceph-radosgw
     num_units: 1
     options:
       source: *openstack-origin
     to:
     - lxd:0
+    channel: quincy/edge
   cinder-mysql-router:
     annotations:
       gui-x: '900'
       gui-y: '1400'
-    charm: cs:~openstack-charmers-next/mysql-router
+    charm: ch:mysql-router
+    channel: 8.0.19/edge
   cinder:
     annotations:
       gui-x: '980'
       gui-y: '1270'
-    charm: cs:~openstack-charmers-next/cinder
+    charm: ch:cinder
     num_units: 1
     options:
       block-device: None
@@ -262,59 +270,67 @@ applications:
       openstack-origin: *openstack-origin
     to:
     - lxd:1
+    channel: yoga/edge
   cinder-ceph:
     annotations:
       gui-x: '1120'
       gui-y: '1400'
-    charm: cs:~openstack-charmers-next/cinder-ceph
+    charm: ch:cinder-ceph
     num_units: 0
+    channel: yoga/edge
   glance-mysql-router:
     annotations:
       gui-x: '-290'
       gui-y: '1400'
-    charm: cs:~openstack-charmers-next/mysql-router
+    charm: ch:mysql-router
+    channel: 8.0.19/edge
   glance:
     annotations:
       gui-x: '-230'
       gui-y: '1270'
-    charm: cs:~openstack-charmers-next/glance
+    charm: ch:glance
     num_units: 1
     options:
       worker-multiplier: *worker-multiplier
       openstack-origin: *openstack-origin
     to:
     - lxd:2
+    channel: yoga/edge
   keystone-mysql-router:
     annotations:
       gui-x: '230'
       gui-y: '1400'
-    charm: cs:~openstack-charmers-next/mysql-router
+    charm: ch:mysql-router
+    channel: 8.0.19/edge
   keystone:
     annotations:
       gui-x: '300'
       gui-y: '1270'
-    charm: cs:~openstack-charmers-next/keystone
+    charm: ch:keystone
     num_units: 1
     options:
       worker-multiplier: *worker-multiplier
       openstack-origin: *openstack-origin
     to:
     - lxd:0
+    channel: yoga/edge
   neutron-mysql-router:
     annotations:
       gui-x: '505'
       gui-y: '1385'
-    charm: cs:~openstack-charmers-next/mysql-router
+    charm: ch:mysql-router
+    channel: 8.0.19/edge
   neutron-api-plugin-ovn:
     annotations:
       gui-x: '690'
       gui-y: '1385'
-    charm: cs:~openstack-charmers-next/neutron-api-plugin-ovn
+    charm: ch:neutron-api-plugin-ovn
+    channel: yoga/edge
   neutron-api:
     annotations:
       gui-x: '580'
       gui-y: '1270'
-    charm: cs:~openstack-charmers-next/neutron-api
+    charm: ch:neutron-api
     num_units: 1
     options:
       neutron-security-groups: true
@@ -323,32 +339,36 @@ applications:
       openstack-origin: *openstack-origin
     to:
     - lxd:1
+    channel: yoga/edge
   placement-mysql-router:
     annotations:
       gui-x: '1320'
       gui-y: '1385'
-    charm: cs:~openstack-charmers-next/mysql-router
+    charm: ch:mysql-router
+    channel: 8.0.19/edge
   placement:
     annotations:
       gui-x: '1320'
       gui-y: '1270'
-    charm: cs:~openstack-charmers-next/placement
+    charm: ch:placement
     num_units: 1
     options:
       worker-multiplier: *worker-multiplier
       openstack-origin: *openstack-origin
     to:
     - lxd:2
+    channel: yoga/edge
   nova-mysql-router:
     annotations:
       gui-x: '-30'
       gui-y: '1385'
-    charm: cs:~openstack-charmers-next/mysql-router
+    charm: ch:mysql-router
+    channel: 8.0.19/edge
   nova-cloud-controller:
     annotations:
       gui-x: '35'
       gui-y: '1270'
-    charm: cs:~openstack-charmers-next/nova-cloud-controller
+    charm: ch:nova-cloud-controller
     num_units: 1
     options:
       network-manager: Neutron
@@ -356,11 +376,12 @@ applications:
       openstack-origin: *openstack-origin
     to:
     - lxd:0
+    channel: yoga/edge
   nova-compute:
     annotations:
       gui-x: '190'
       gui-y: '890'
-    charm: cs:~openstack-charmers-next/nova-compute
+    charm: ch:nova-compute
     num_units: 3
     options:
       config-flags: default_ephemeral_format=ext4
@@ -372,50 +393,55 @@ applications:
     - '0'
     - '1'
     - '2'
+    channel: yoga/edge
   ntp:
     annotations:
       gui-x: '315'
       gui-y: '1030'
-    charm: cs:ntp
+    charm: ch:ntp
     num_units: 0
   dashboard-mysql-router:
     annotations:
       gui-x: '510'
       gui-y: '1030'
-    charm: cs:~openstack-charmers-next/mysql-router
+    charm: ch:mysql-router
+    channel: 8.0.19/edge
   openstack-dashboard:
     annotations:
       gui-x: '585'
       gui-y: '900'
-    charm: cs:~openstack-charmers-next/openstack-dashboard
+    charm: ch:openstack-dashboard
     num_units: 1
     options:
       openstack-origin: *openstack-origin
     to:
     - lxd:1
+    channel: yoga/edge
   rabbitmq-server:
     annotations:
       gui-x: '300'
       gui-y: '1550'
-    charm: cs:~openstack-charmers-next/rabbitmq-server
+    charm: ch:rabbitmq-server
     num_units: 1
     to:
     - lxd:2
+    channel: 3.9/edge
   mysql-innodb-cluster:
     annotations:
       gui-x: '535'
       gui-y: '1550'
-    charm: cs:~openstack-charmers-next/mysql-innodb-cluster
+    charm: ch:mysql-innodb-cluster
     num_units: 3
     to:
     - lxd:0
     - lxd:1
     - lxd:2
+    channel: 8.0.19/edge
   ovn-central:
     annotations:
       gui-x: '70'
       gui-y: '1550'
-    charm: cs:~openstack-charmers-next/ovn-central
+    charm: ch:ovn-central
     num_units: 3
     options:
       source: *openstack-origin
@@ -423,27 +449,31 @@ applications:
     - lxd:0
     - lxd:1
     - lxd:2
+    channel: 22.03/edge
   ovn-chassis:
     annotations:
       gui-x: '120'
       gui-y: '1030'
-    charm: cs:~openstack-charmers-next/ovn-chassis
+    charm: ch:ovn-chassis
     # Please update the `bridge-interface-mappings` to values suitable for the
     # hardware used in your deployment. See the referenced documentation at the
     # top of this file.
     options:
       ovn-bridge-mappings: physnet1:br-ex
       bridge-interface-mappings: *data-port
+    channel: 22.03/edge
   vault-mysql-router:
     annotations:
       gui-x: '1535'
       gui-y: '1560'
-    charm: cs:~openstack-charmers-next/mysql-router
+    charm: ch:mysql-router
+    channel: 8.0.19/edge
   vault:
     annotations:
       gui-x: '1610'
       gui-y: '1430'
-    charm: cs:vault
+    charm: ch:vault
+    channel: 1.7/edge
     num_units: 1
     to:
     - lxd:0
@@ -452,19 +482,21 @@ applications:
       gui-x: '1500'
       gui-y: '250'
     num_units: 1
-    charm: cs:~openstack-charmers-next/gnocchi
+    charm: ch:gnocchi
     options:
       openstack-origin: *openstack-origin
     to:
     - lxd:1
+    channel: yoga/edge
   gnocchi-mysql-router:
-    charm: cs:~openstack-charmers-next/mysql-router
+    charm: ch:mysql-router
+    channel: 8.0.19/edge
   memcached:
     series: bionic
     annotations:
       gui-x: '1500'
       gui-y: '500'
     num_units: 1
-    charm: cs:memcached
+    charm: ch:memcached
     to:
     - lxd:2


### PR DESCRIPTION
This patch drops the use of the `cs:` prefix in favor of `ch:` and the
channel is set to `yoga/edge` for openstack charms, and quincy/edge for
Ceph.