### PR TITLE
Remove worker-multiplier from openstack-base bundle

### DIFF
--- a/development/openstack-base-focal-yoga/bundle.yaml
+++ b/development/openstack-base-focal-yoga/bundle.yaml
@@ -11,7 +11,6 @@ series: focal
 variables:
   openstack-origin: &openstack-origin cloud:focal-yoga
   data-port: &data-port to-be-set
-  worker-multiplier: &worker-multiplier 0.25
   osd-devices: &osd-devices /dev/sdb /dev/vdb
   expected-osd-count: &expected-osd-count 3
   expected-mon-count: &expected-mon-count 3
@@ -194,7 +193,6 @@ applications:
     options:
       block-device: None
       glance-api-version: 2
-      worker-multiplier: *worker-multiplier
       openstack-origin: *openstack-origin
     to:
     - lxd:1
@@ -219,7 +217,6 @@ applications:
     charm: ch:glance
     num_units: 1
     options:
-      worker-multiplier: *worker-multiplier
       openstack-origin: *openstack-origin
     to:
     - lxd:2
@@ -237,7 +234,6 @@ applications:
     charm: ch:keystone
     num_units: 1
     options:
-      worker-multiplier: *worker-multiplier
       openstack-origin: *openstack-origin
     to:
     - lxd:0
@@ -263,7 +259,6 @@ applications:
     options:
       neutron-security-groups: true
       flat-network-providers: physnet1
-      worker-multiplier: *worker-multiplier
       openstack-origin: *openstack-origin
     to:
     - lxd:1
@@ -281,7 +276,6 @@ applications:
     charm: ch:placement
     num_units: 1
     options:
-      worker-multiplier: *worker-multiplier
       openstack-origin: *openstack-origin
     to:
     - lxd:2
@@ -300,7 +294,6 @@ applications:
     num_units: 1
     options:
       network-manager: Neutron
-      worker-multiplier: *worker-multiplier
       openstack-origin: *openstack-origin
     to:
     - lxd:0

--- a/development/openstack-base-jammy-yoga/bundle.yaml
+++ b/development/openstack-base-jammy-yoga/bundle.yaml
@@ -13,7 +13,6 @@ series: jammy
 variables:
   openstack-origin: &openstack-origin distro
   data-port: &data-port to-be-set
-  worker-multiplier: &worker-multiplier 0.25
   osd-devices: &osd-devices /dev/sdb /dev/vdb
   expected-osd-count: &expected-osd-count 3
   expected-mon-count: &expected-mon-count 3
@@ -196,7 +195,6 @@ applications:
     options:
       block-device: None
       glance-api-version: 2
-      worker-multiplier: *worker-multiplier
       openstack-origin: *openstack-origin
     to:
     - lxd:1
@@ -221,7 +219,6 @@ applications:
     charm: ch:glance
     num_units: 1
     options:
-      worker-multiplier: *worker-multiplier
       openstack-origin: *openstack-origin
     to:
     - lxd:2
@@ -239,7 +236,6 @@ applications:
     charm: ch:keystone
     num_units: 1
     options:
-      worker-multiplier: *worker-multiplier
       openstack-origin: *openstack-origin
     to:
     - lxd:0
@@ -265,7 +261,6 @@ applications:
     options:
       neutron-security-groups: true
       flat-network-providers: physnet1
-      worker-multiplier: *worker-multiplier
       openstack-origin: *openstack-origin
     to:
     - lxd:1
@@ -283,7 +278,6 @@ applications:
     charm: ch:placement
     num_units: 1
     options:
-      worker-multiplier: *worker-multiplier
       openstack-origin: *openstack-origin
     to:
     - lxd:2
@@ -302,7 +296,6 @@ applications:
     num_units: 1
     options:
       network-manager: Neutron
-      worker-multiplier: *worker-multiplier
       openstack-origin: *openstack-origin
     to:
     - lxd:0


### PR DESCRIPTION
There is already a cap of four service workers for both containerised and non-containerised machines when the `worker-multiplier` option is unset. Setting it to a low value (such as the current `0.25`) can still lead to too many workers on highly resourced machines. This PR unsets it for containerised services. The bundle variable was removed entirely since this option was *only* being set for containerised services. This affects openstack-base bundles **focal-yoga** and **jammy-yoga**.