### PR TITLE
Drop legacy charm urls from bundles

### DIFF
--- a/development/openstack-base-bionic-queens/bundle.yaml
+++ b/development/openstack-base-bionic-queens/bundle.yaml
@@ -88,7 +88,7 @@ services:
     annotations:
       gui-x: '750'
       gui-y: '500'
-    charm: cs:~openstack-charmers-next/bionic/ceph-mon
+    charm: cs:~openstack-charmers-next/ceph-mon
     num_units: 3
     options:
       expected-osd-count: 3
@@ -100,7 +100,7 @@ services:
     annotations:
       gui-x: '1000'
       gui-y: '500'
-    charm: cs:~openstack-charmers-next/bionic/ceph-osd
+    charm: cs:~openstack-charmers-next/ceph-osd
     num_units: 3
     options:
       osd-devices: /dev/sdb
@@ -112,7 +112,7 @@ services:
     annotations:
       gui-x: '1000'
       gui-y: '250'
-    charm: cs:~openstack-charmers-next/bionic/ceph-radosgw
+    charm: cs:~openstack-charmers-next/ceph-radosgw
     num_units: 1
     to:
     - lxd:0
@@ -120,7 +120,7 @@ services:
     annotations:
       gui-x: '750'
       gui-y: '0'
-    charm: cs:~openstack-charmers-next/bionic/cinder
+    charm: cs:~openstack-charmers-next/cinder
     num_units: 1
     options:
       block-device: None
@@ -132,13 +132,13 @@ services:
     annotations:
       gui-x: '750'
       gui-y: '250'
-    charm: cs:~openstack-charmers-next/bionic/cinder-ceph
+    charm: cs:~openstack-charmers-next/cinder-ceph
     num_units: 0
   glance:
     annotations:
       gui-x: '250'
       gui-y: '0'
-    charm: cs:~openstack-charmers-next/bionic/glance
+    charm: cs:~openstack-charmers-next/glance
     num_units: 1
     options:
       worker-multiplier: 0.25
@@ -148,7 +148,7 @@ services:
     annotations:
       gui-x: '500'
       gui-y: '0'
-    charm: cs:~openstack-charmers-next/bionic/keystone
+    charm: cs:~openstack-charmers-next/keystone
     num_units: 1
     options:
       worker-multiplier: 0.25
@@ -158,7 +158,7 @@ services:
     annotations:
       gui-x: '0'
       gui-y: '250'
-    charm: cs:~openstack-charmers-next/bionic/percona-cluster
+    charm: cs:~openstack-charmers-next/percona-cluster
     num_units: 1
     options:
       max-connections: 1000
@@ -169,7 +169,7 @@ services:
     annotations:
       gui-x: '500'
       gui-y: '500'
-    charm: cs:~openstack-charmers-next/bionic/neutron-api
+    charm: cs:~openstack-charmers-next/neutron-api
     num_units: 1
     options:
       neutron-security-groups: true
@@ -181,7 +181,7 @@ services:
     annotations:
       gui-x: '0'
       gui-y: '0'
-    charm: cs:~openstack-charmers-next/bionic/neutron-gateway
+    charm: cs:~openstack-charmers-next/neutron-gateway
     num_units: 1
     options:
       bridge-mappings: physnet1:br-ex
@@ -193,13 +193,13 @@ services:
     annotations:
       gui-x: '250'
       gui-y: '500'
-    charm: cs:~openstack-charmers-next/bionic/neutron-openvswitch
+    charm: cs:~openstack-charmers-next/neutron-openvswitch
     num_units: 0
   nova-cloud-controller:
     annotations:
       gui-x: '0'
       gui-y: '500'
-    charm: cs:~openstack-charmers-next/bionic/nova-cloud-controller
+    charm: cs:~openstack-charmers-next/nova-cloud-controller
     num_units: 1
     options:
       network-manager: Neutron
@@ -210,7 +210,7 @@ services:
     annotations:
       gui-x: '250'
       gui-y: '250'
-    charm: cs:~openstack-charmers-next/bionic/nova-compute
+    charm: cs:~openstack-charmers-next/nova-compute
     num_units: 3
     options:
       config-flags: default_ephemeral_format=ext4
@@ -231,7 +231,7 @@ services:
     annotations:
       gui-x: '500'
       gui-y: '-250'
-    charm: cs:~openstack-charmers-next/bionic/openstack-dashboard
+    charm: cs:~openstack-charmers-next/openstack-dashboard
     num_units: 1
     to:
     - lxd:3
@@ -239,7 +239,7 @@ services:
     annotations:
       gui-x: '500'
       gui-y: '250'
-    charm: cs:~openstack-charmers-next/bionic/rabbitmq-server
+    charm: cs:~openstack-charmers-next/rabbitmq-server
     num_units: 1
     to:
     - lxd:0

--- a/development/openstack-base-bionic-rocky/bundle.yaml
+++ b/development/openstack-base-bionic-rocky/bundle.yaml
@@ -90,7 +90,7 @@ services:
     annotations:
       gui-x: '750'
       gui-y: '500'
-    charm: cs:~openstack-charmers-next/bionic/ceph-mon
+    charm: cs:~openstack-charmers-next/ceph-mon
     num_units: 3
     options:
       expected-osd-count: 3
@@ -103,7 +103,7 @@ services:
     annotations:
       gui-x: '1000'
       gui-y: '500'
-    charm: cs:~openstack-charmers-next/bionic/ceph-osd
+    charm: cs:~openstack-charmers-next/ceph-osd
     num_units: 3
     options:
       osd-devices: /dev/sdb
@@ -116,7 +116,7 @@ services:
     annotations:
       gui-x: '1000'
       gui-y: '250'
-    charm: cs:~openstack-charmers-next/bionic/ceph-radosgw
+    charm: cs:~openstack-charmers-next/ceph-radosgw
     num_units: 1
     options:
       source: cloud:bionic-rocky
@@ -126,7 +126,7 @@ services:
     annotations:
       gui-x: '750'
       gui-y: '0'
-    charm: cs:~openstack-charmers-next/bionic/cinder
+    charm: cs:~openstack-charmers-next/cinder
     num_units: 1
     options:
       block-device: None
@@ -139,13 +139,13 @@ services:
     annotations:
       gui-x: '750'
       gui-y: '250'
-    charm: cs:~openstack-charmers-next/bionic/cinder-ceph
+    charm: cs:~openstack-charmers-next/cinder-ceph
     num_units: 0
   glance:
     annotations:
       gui-x: '250'
       gui-y: '0'
-    charm: cs:~openstack-charmers-next/bionic/glance
+    charm: cs:~openstack-charmers-next/glance
     num_units: 1
     options:
       worker-multiplier: 0.25
@@ -156,7 +156,7 @@ services:
     annotations:
       gui-x: '500'
       gui-y: '0'
-    charm: cs:~openstack-charmers-next/bionic/keystone
+    charm: cs:~openstack-charmers-next/keystone
     num_units: 1
     options:
       worker-multiplier: 0.25
@@ -167,7 +167,7 @@ services:
     annotations:
       gui-x: '0'
       gui-y: '250'
-    charm: cs:~openstack-charmers-next/bionic/percona-cluster
+    charm: cs:~openstack-charmers-next/percona-cluster
     num_units: 1
     options:
       max-connections: 1000
@@ -178,7 +178,7 @@ services:
     annotations:
       gui-x: '500'
       gui-y: '500'
-    charm: cs:~openstack-charmers-next/bionic/neutron-api
+    charm: cs:~openstack-charmers-next/neutron-api
     num_units: 1
     options:
       neutron-security-groups: true
@@ -191,7 +191,7 @@ services:
     annotations:
       gui-x: '0'
       gui-y: '0'
-    charm: cs:~openstack-charmers-next/bionic/neutron-gateway
+    charm: cs:~openstack-charmers-next/neutron-gateway
     num_units: 1
     options:
       bridge-mappings: physnet1:br-ex
@@ -204,13 +204,13 @@ services:
     annotations:
       gui-x: '250'
       gui-y: '500'
-    charm: cs:~openstack-charmers-next/bionic/neutron-openvswitch
+    charm: cs:~openstack-charmers-next/neutron-openvswitch
     num_units: 0
   nova-cloud-controller:
     annotations:
       gui-x: '0'
       gui-y: '500'
-    charm: cs:~openstack-charmers-next/bionic/nova-cloud-controller
+    charm: cs:~openstack-charmers-next/nova-cloud-controller
     num_units: 1
     options:
       network-manager: Neutron
@@ -222,7 +222,7 @@ services:
     annotations:
       gui-x: '250'
       gui-y: '250'
-    charm: cs:~openstack-charmers-next/bionic/nova-compute
+    charm: cs:~openstack-charmers-next/nova-compute
     num_units: 3
     options:
       config-flags: default_ephemeral_format=ext4
@@ -244,7 +244,7 @@ services:
     annotations:
       gui-x: '500'
       gui-y: '-250'
-    charm: cs:~openstack-charmers-next/bionic/openstack-dashboard
+    charm: cs:~openstack-charmers-next/openstack-dashboard
     num_units: 1
     options:
       openstack-origin: cloud:bionic-rocky
@@ -254,7 +254,7 @@ services:
     annotations:
       gui-x: '500'
       gui-y: '250'
-    charm: cs:~openstack-charmers-next/bionic/rabbitmq-server
+    charm: cs:~openstack-charmers-next/rabbitmq-server
     num_units: 1
     to:
     - lxd:0

--- a/development/openstack-base-bionic-stein/bundle.yaml
+++ b/development/openstack-base-bionic-stein/bundle.yaml
@@ -104,7 +104,7 @@ services:
     annotations:
       gui-x: '750'
       gui-y: '500'
-    charm: cs:~openstack-charmers-next/bionic/ceph-mon
+    charm: cs:~openstack-charmers-next/ceph-mon
     num_units: 3
     options:
       expected-osd-count: *expected-osd-count
@@ -118,7 +118,7 @@ services:
     annotations:
       gui-x: '1000'
       gui-y: '500'
-    charm: cs:~openstack-charmers-next/bionic/ceph-osd
+    charm: cs:~openstack-charmers-next/ceph-osd
     num_units: 3
     options:
       osd-devices: *osd-devices
@@ -131,7 +131,7 @@ services:
     annotations:
       gui-x: '1000'
       gui-y: '250'
-    charm: cs:~openstack-charmers-next/bionic/ceph-radosgw
+    charm: cs:~openstack-charmers-next/ceph-radosgw
     num_units: 1
     options:
       source: *openstack-origin
@@ -141,7 +141,7 @@ services:
     annotations:
       gui-x: '750'
       gui-y: '0'
-    charm: cs:~openstack-charmers-next/bionic/cinder
+    charm: cs:~openstack-charmers-next/cinder
     num_units: 1
     options:
       block-device: None
@@ -154,13 +154,13 @@ services:
     annotations:
       gui-x: '750'
       gui-y: '250'
-    charm: cs:~openstack-charmers-next/bionic/cinder-ceph
+    charm: cs:~openstack-charmers-next/cinder-ceph
     num_units: 0
   glance:
     annotations:
       gui-x: '250'
       gui-y: '0'
-    charm: cs:~openstack-charmers-next/bionic/glance
+    charm: cs:~openstack-charmers-next/glance
     num_units: 1
     options:
       worker-multiplier: *worker-multiplier
@@ -171,7 +171,7 @@ services:
     annotations:
       gui-x: '500'
       gui-y: '0'
-    charm: cs:~openstack-charmers-next/bionic/keystone
+    charm: cs:~openstack-charmers-next/keystone
     num_units: 1
     options:
       worker-multiplier: *worker-multiplier
@@ -182,7 +182,7 @@ services:
     annotations:
       gui-x: '0'
       gui-y: '250'
-    charm: cs:~openstack-charmers-next/bionic/percona-cluster
+    charm: cs:~openstack-charmers-next/percona-cluster
     num_units: 1
     options:
       max-connections: *mysql-connections
@@ -194,7 +194,7 @@ services:
     annotations:
       gui-x: '500'
       gui-y: '500'
-    charm: cs:~openstack-charmers-next/bionic/neutron-api
+    charm: cs:~openstack-charmers-next/neutron-api
     num_units: 1
     options:
       neutron-security-groups: true
@@ -207,7 +207,7 @@ services:
     annotations:
       gui-x: '0'
       gui-y: '0'
-    charm: cs:~openstack-charmers-next/bionic/neutron-gateway
+    charm: cs:~openstack-charmers-next/neutron-gateway
     num_units: 1
     options:
       bridge-mappings: physnet1:br-ex
@@ -220,13 +220,13 @@ services:
     annotations:
       gui-x: '250'
       gui-y: '500'
-    charm: cs:~openstack-charmers-next/bionic/neutron-openvswitch
+    charm: cs:~openstack-charmers-next/neutron-openvswitch
     num_units: 0
   nova-cloud-controller:
     annotations:
       gui-x: '0'
       gui-y: '500'
-    charm: cs:~openstack-charmers-next/bionic/nova-cloud-controller
+    charm: cs:~openstack-charmers-next/nova-cloud-controller
     num_units: 1
     options:
       network-manager: Neutron
@@ -238,7 +238,7 @@ services:
     annotations:
       gui-x: '250'
       gui-y: '250'
-    charm: cs:~openstack-charmers-next/bionic/nova-compute
+    charm: cs:~openstack-charmers-next/nova-compute
     num_units: 3
     options:
       config-flags: default_ephemeral_format=ext4
@@ -260,7 +260,7 @@ services:
     annotations:
       gui-x: '500'
       gui-y: '-250'
-    charm: cs:~openstack-charmers-next/bionic/openstack-dashboard
+    charm: cs:~openstack-charmers-next/openstack-dashboard
     num_units: 1
     options:
       openstack-origin: *openstack-origin
@@ -270,7 +270,7 @@ services:
     annotations:
       gui-x: '500'
       gui-y: '250'
-    charm: cs:~openstack-charmers-next/bionic/rabbitmq-server
+    charm: cs:~openstack-charmers-next/rabbitmq-server
     num_units: 1
     to:
     - 'lxd:0'

--- a/development/openstack-base-bionic-train/bundle.yaml
+++ b/development/openstack-base-bionic-train/bundle.yaml
@@ -110,7 +110,7 @@ services:
     annotations:
       gui-x: '750'
       gui-y: '500'
-    charm: cs:~openstack-charmers-next/bionic/ceph-mon
+    charm: cs:~openstack-charmers-next/ceph-mon
     num_units: 3
     options:
       expected-osd-count: *expected-osd-count
@@ -124,7 +124,7 @@ services:
     annotations:
       gui-x: '1000'
       gui-y: '500'
-    charm: cs:~openstack-charmers-next/bionic/ceph-osd
+    charm: cs:~openstack-charmers-next/ceph-osd
     num_units: 3
     options:
       osd-devices: *osd-devices
@@ -137,7 +137,7 @@ services:
     annotations:
       gui-x: '1000'
       gui-y: '250'
-    charm: cs:~openstack-charmers-next/bionic/ceph-radosgw
+    charm: cs:~openstack-charmers-next/ceph-radosgw
     num_units: 1
     options:
       source: *openstack-origin
@@ -147,7 +147,7 @@ services:
     annotations:
       gui-x: '750'
       gui-y: '0'
-    charm: cs:~openstack-charmers-next/bionic/cinder
+    charm: cs:~openstack-charmers-next/cinder
     num_units: 1
     options:
       block-device: None
@@ -160,13 +160,13 @@ services:
     annotations:
       gui-x: '750'
       gui-y: '250'
-    charm: cs:~openstack-charmers-next/bionic/cinder-ceph
+    charm: cs:~openstack-charmers-next/cinder-ceph
     num_units: 0
   glance:
     annotations:
       gui-x: '250'
       gui-y: '0'
-    charm: cs:~openstack-charmers-next/bionic/glance
+    charm: cs:~openstack-charmers-next/glance
     num_units: 1
     options:
       worker-multiplier: *worker-multiplier
@@ -177,7 +177,7 @@ services:
     annotations:
       gui-x: '500'
       gui-y: '0'
-    charm: cs:~openstack-charmers-next/bionic/keystone
+    charm: cs:~openstack-charmers-next/keystone
     num_units: 1
     options:
       worker-multiplier: *worker-multiplier
@@ -188,7 +188,7 @@ services:
     annotations:
       gui-x: '0'
       gui-y: '250'
-    charm: cs:~openstack-charmers-next/bionic/percona-cluster
+    charm: cs:~openstack-charmers-next/percona-cluster
     num_units: 1
     options:
       max-connections: *mysql-connections
@@ -200,7 +200,7 @@ services:
     annotations:
       gui-x: '500'
       gui-y: '500'
-    charm: cs:~openstack-charmers-next/bionic/neutron-api
+    charm: cs:~openstack-charmers-next/neutron-api
     num_units: 1
     options:
       neutron-security-groups: true
@@ -213,7 +213,7 @@ services:
     annotations:
       gui-x: '0'
       gui-y: '500'
-    charm: cs:~openstack-charmers-next/bionic/placement
+    charm: cs:~openstack-charmers-next/placement
     num_units: 1
     options:
       worker-multiplier: *worker-multiplier
@@ -224,7 +224,7 @@ services:
     annotations:
       gui-x: '0'
       gui-y: '0'
-    charm: cs:~openstack-charmers-next/bionic/neutron-gateway
+    charm: cs:~openstack-charmers-next/neutron-gateway
     num_units: 1
     options:
       bridge-mappings: physnet1:br-ex
@@ -237,13 +237,13 @@ services:
     annotations:
       gui-x: '250'
       gui-y: '500'
-    charm: cs:~openstack-charmers-next/bionic/neutron-openvswitch
+    charm: cs:~openstack-charmers-next/neutron-openvswitch
     num_units: 0
   nova-cloud-controller:
     annotations:
       gui-x: '0'
       gui-y: '500'
-    charm: cs:~openstack-charmers-next/bionic/nova-cloud-controller
+    charm: cs:~openstack-charmers-next/nova-cloud-controller
     num_units: 1
     options:
       network-manager: Neutron
@@ -255,7 +255,7 @@ services:
     annotations:
       gui-x: '250'
       gui-y: '250'
-    charm: cs:~openstack-charmers-next/bionic/nova-compute
+    charm: cs:~openstack-charmers-next/nova-compute
     num_units: 3
     options:
       config-flags: default_ephemeral_format=ext4
@@ -277,7 +277,7 @@ services:
     annotations:
       gui-x: '500'
       gui-y: '-250'
-    charm: cs:~openstack-charmers-next/bionic/openstack-dashboard
+    charm: cs:~openstack-charmers-next/openstack-dashboard
     num_units: 1
     options:
       openstack-origin: *openstack-origin
@@ -287,7 +287,7 @@ services:
     annotations:
       gui-x: '500'
       gui-y: '250'
-    charm: cs:~openstack-charmers-next/bionic/rabbitmq-server
+    charm: cs:~openstack-charmers-next/rabbitmq-server
     num_units: 1
     to:
     - 'lxd:0'

--- a/development/openstack-base-bionic-ussuri/bundle.yaml
+++ b/development/openstack-base-bionic-ussuri/bundle.yaml
@@ -110,7 +110,7 @@ services:
     annotations:
       gui-x: '750'
       gui-y: '500'
-    charm: cs:~openstack-charmers-next/bionic/ceph-mon
+    charm: cs:~openstack-charmers-next/ceph-mon
     num_units: 3
     options:
       expected-osd-count: *expected-osd-count
@@ -124,7 +124,7 @@ services:
     annotations:
       gui-x: '1000'
       gui-y: '500'
-    charm: cs:~openstack-charmers-next/bionic/ceph-osd
+    charm: cs:~openstack-charmers-next/ceph-osd
     num_units: 3
     options:
       osd-devices: *osd-devices
@@ -137,7 +137,7 @@ services:
     annotations:
       gui-x: '1000'
       gui-y: '250'
-    charm: cs:~openstack-charmers-next/bionic/ceph-radosgw
+    charm: cs:~openstack-charmers-next/ceph-radosgw
     num_units: 1
     options:
       source: *openstack-origin
@@ -147,7 +147,7 @@ services:
     annotations:
       gui-x: '750'
       gui-y: '0'
-    charm: cs:~openstack-charmers-next/bionic/cinder
+    charm: cs:~openstack-charmers-next/cinder
     num_units: 1
     options:
       block-device: None
@@ -160,13 +160,13 @@ services:
     annotations:
       gui-x: '750'
       gui-y: '250'
-    charm: cs:~openstack-charmers-next/bionic/cinder-ceph
+    charm: cs:~openstack-charmers-next/cinder-ceph
     num_units: 0
   glance:
     annotations:
       gui-x: '250'
       gui-y: '0'
-    charm: cs:~openstack-charmers-next/bionic/glance
+    charm: cs:~openstack-charmers-next/glance
     num_units: 1
     options:
       worker-multiplier: *worker-multiplier
@@ -177,7 +177,7 @@ services:
     annotations:
       gui-x: '500'
       gui-y: '0'
-    charm: cs:~openstack-charmers-next/bionic/keystone
+    charm: cs:~openstack-charmers-next/keystone
     num_units: 1
     options:
       worker-multiplier: *worker-multiplier
@@ -188,7 +188,7 @@ services:
     annotations:
       gui-x: '0'
       gui-y: '250'
-    charm: cs:~openstack-charmers-next/bionic/percona-cluster
+    charm: cs:~openstack-charmers-next/percona-cluster
     num_units: 1
     options:
       max-connections: *mysql-connections
@@ -200,7 +200,7 @@ services:
     annotations:
       gui-x: '500'
       gui-y: '500'
-    charm: cs:~openstack-charmers-next/bionic/neutron-api
+    charm: cs:~openstack-charmers-next/neutron-api
     num_units: 1
     options:
       manage-neutron-plugin-legacy-mode: true
@@ -214,7 +214,7 @@ services:
     annotations:
       gui-x: '0'
       gui-y: '500'
-    charm: cs:~openstack-charmers-next/bionic/placement
+    charm: cs:~openstack-charmers-next/placement
     num_units: 1
     options:
       worker-multiplier: *worker-multiplier
@@ -225,7 +225,7 @@ services:
     annotations:
       gui-x: '0'
       gui-y: '0'
-    charm: cs:~openstack-charmers-next/bionic/neutron-gateway
+    charm: cs:~openstack-charmers-next/neutron-gateway
     num_units: 1
     options:
       bridge-mappings: physnet1:br-ex
@@ -238,13 +238,13 @@ services:
     annotations:
       gui-x: '250'
       gui-y: '500'
-    charm: cs:~openstack-charmers-next/bionic/neutron-openvswitch
+    charm: cs:~openstack-charmers-next/neutron-openvswitch
     num_units: 0
   nova-cloud-controller:
     annotations:
       gui-x: '0'
       gui-y: '500'
-    charm: cs:~openstack-charmers-next/bionic/nova-cloud-controller
+    charm: cs:~openstack-charmers-next/nova-cloud-controller
     num_units: 1
     options:
       network-manager: Neutron
@@ -256,7 +256,7 @@ services:
     annotations:
       gui-x: '250'
       gui-y: '250'
-    charm: cs:~openstack-charmers-next/bionic/nova-compute
+    charm: cs:~openstack-charmers-next/nova-compute
     num_units: 3
     options:
       config-flags: default_ephemeral_format=ext4
@@ -278,7 +278,7 @@ services:
     annotations:
       gui-x: '500'
       gui-y: '-250'
-    charm: cs:~openstack-charmers-next/bionic/openstack-dashboard
+    charm: cs:~openstack-charmers-next/openstack-dashboard
     num_units: 1
     options:
       openstack-origin: *openstack-origin
@@ -288,7 +288,7 @@ services:
     annotations:
       gui-x: '500'
       gui-y: '250'
-    charm: cs:~openstack-charmers-next/bionic/rabbitmq-server
+    charm: cs:~openstack-charmers-next/rabbitmq-server
     num_units: 1
     to:
     - 'lxd:0'

--- a/development/openstack-base-eoan-train-mysql8-migration/bundle.yaml
+++ b/development/openstack-base-eoan-train-mysql8-migration/bundle.yaml
@@ -131,7 +131,7 @@ applications:
     annotations:
       gui-x: '750'
       gui-y: '500'
-    charm: cs:~openstack-charmers-next/eoan/ceph-mon
+    charm: cs:~openstack-charmers-next/ceph-mon
     num_units: 3
     options:
       expected-osd-count: *expected-osd-count
@@ -145,7 +145,7 @@ applications:
     annotations:
       gui-x: '1000'
       gui-y: '500'
-    charm: cs:~openstack-charmers-next/eoan/ceph-osd
+    charm: cs:~openstack-charmers-next/ceph-osd
     num_units: 3
     options:
       osd-devices: *osd-devices
@@ -158,7 +158,7 @@ applications:
     annotations:
       gui-x: '1000'
       gui-y: '250'
-    charm: cs:~openstack-charmers-next/eoan/ceph-radosgw
+    charm: cs:~openstack-charmers-next/ceph-radosgw
     num_units: 1
     options:
       source: *openstack-origin
@@ -168,7 +168,7 @@ applications:
     annotations:
       gui-x: '750'
       gui-y: '0'
-    charm: cs:~openstack-charmers-next/eoan/cinder
+    charm: cs:~openstack-charmers-next/cinder
     num_units: 1
     options:
       block-device: None
@@ -181,13 +181,13 @@ applications:
     annotations:
       gui-x: '750'
       gui-y: '250'
-    charm: cs:~openstack-charmers-next/eoan/cinder-ceph
+    charm: cs:~openstack-charmers-next/cinder-ceph
     num_units: 0
   glance:
     annotations:
       gui-x: '250'
       gui-y: '0'
-    charm: cs:~openstack-charmers-next/eoan/glance
+    charm: cs:~openstack-charmers-next/glance
     num_units: 1
     options:
       worker-multiplier: *worker-multiplier
@@ -198,7 +198,7 @@ applications:
     annotations:
       gui-x: '500'
       gui-y: '0'
-    charm: cs:~openstack-charmers-next/eoan/keystone
+    charm: cs:~openstack-charmers-next/keystone
     num_units: 1
     options:
       worker-multiplier: *worker-multiplier
@@ -209,7 +209,7 @@ applications:
     annotations:
       gui-x: '500'
       gui-y: '500'
-    charm: cs:~openstack-charmers-next/eoan/neutron-api
+    charm: cs:~openstack-charmers-next/neutron-api
     num_units: 1
     options:
       neutron-security-groups: true
@@ -223,7 +223,7 @@ applications:
     annotations:
       gui-x: '0'
       gui-y: '500'
-    charm: cs:~openstack-charmers-next/eoan/placement
+    charm: cs:~openstack-charmers-next/placement
     num_units: 1
     options:
       worker-multiplier: *worker-multiplier
@@ -234,7 +234,7 @@ applications:
     annotations:
       gui-x: '0'
       gui-y: '500'
-    charm: cs:~openstack-charmers-next/eoan/nova-cloud-controller
+    charm: cs:~openstack-charmers-next/nova-cloud-controller
     num_units: 1
     options:
       network-manager: Neutron
@@ -246,7 +246,7 @@ applications:
     annotations:
       gui-x: '250'
       gui-y: '250'
-    charm: cs:~openstack-charmers-next/eoan/nova-compute
+    charm: cs:~openstack-charmers-next/nova-compute
     num_units: 3
     options:
       config-flags: default_ephemeral_format=ext4
@@ -269,7 +269,7 @@ applications:
     annotations:
       gui-x: '500'
       gui-y: '-250'
-    charm: cs:~openstack-charmers-next/eoan/openstack-dashboard
+    charm: cs:~openstack-charmers-next/openstack-dashboard
     num_units: 1
     options:
       openstack-origin: *openstack-origin
@@ -279,7 +279,7 @@ applications:
     annotations:
       gui-x: '500'
       gui-y: '250'
-    charm: cs:~openstack-charmers-next/eoan/rabbitmq-server
+    charm: cs:~openstack-charmers-next/rabbitmq-server
     num_units: 1
     to:
     - 'lxd:0'
@@ -307,16 +307,16 @@ applications:
     - 'lxd:1'
     - 'lxd:2'
   neutron-api-plugin-ovn:
-    charm: cs:~openstack-charmers/neutron-api-plugin-ovn
+    charm: cs:~openstack-charmers-next/neutron-api-plugin-ovn
   ovn-central:
-    charm: cs:~openstack-charmers/ovn-central
+    charm: cs:~openstack-charmers-next/ovn-central
     num_units: 3
     to:
     - 'lxd:0'
     - 'lxd:1'
     - 'lxd:2'
   ovn-chassis:
-    charm: cs:~openstack-charmers/ovn-chassis
+    charm: cs:~openstack-charmers-next/ovn-chassis
     # Please update the `bridge-interface-mappings` to values suitable for the
     # hardware used in your deployment. See the referenced documentation at the
     # top of this file.
@@ -329,7 +329,7 @@ applications:
     to:
     - 'lxd:0'
   percona-cluster:
-    charm: cs:~openstack-charmers/percona-cluster
+    charm: cs:~openstack-charmers-next/percona-cluster
     num_units: 1
     to:
     - 'lxd:1'

--- a/development/openstack-base-eoan-train-mysql8-ovn/bundle.yaml
+++ b/development/openstack-base-eoan-train-mysql8-ovn/bundle.yaml
@@ -145,7 +145,7 @@ applications:
     annotations:
       gui-x: '750'
       gui-y: '500'
-    charm: cs:~openstack-charmers-next/eoan/ceph-mon
+    charm: cs:~openstack-charmers-next/ceph-mon
     num_units: 3
     options:
       expected-osd-count: *expected-osd-count
@@ -159,7 +159,7 @@ applications:
     annotations:
       gui-x: '1000'
       gui-y: '500'
-    charm: cs:~openstack-charmers-next/eoan/ceph-osd
+    charm: cs:~openstack-charmers-next/ceph-osd
     num_units: 3
     options:
       osd-devices: *osd-devices
@@ -172,7 +172,7 @@ applications:
     annotations:
       gui-x: '1000'
       gui-y: '250'
-    charm: cs:~openstack-charmers-next/eoan/ceph-radosgw
+    charm: cs:~openstack-charmers-next/ceph-radosgw
     num_units: 1
     options:
       source: *openstack-origin
@@ -184,7 +184,7 @@ applications:
     annotations:
       gui-x: '750'
       gui-y: '0'
-    charm: cs:~openstack-charmers-next/eoan/cinder
+    charm: cs:~openstack-charmers-next/cinder
     num_units: 1
     options:
       block-device: None
@@ -197,7 +197,7 @@ applications:
     annotations:
       gui-x: '750'
       gui-y: '250'
-    charm: cs:~openstack-charmers-next/eoan/cinder-ceph
+    charm: cs:~openstack-charmers-next/cinder-ceph
     num_units: 0
   glance-mysql-router:
     charm: cs:~openstack-charmers-next/mysql-router
@@ -205,7 +205,7 @@ applications:
     annotations:
       gui-x: '250'
       gui-y: '0'
-    charm: cs:~openstack-charmers-next/eoan/glance
+    charm: cs:~openstack-charmers-next/glance
     num_units: 1
     options:
       worker-multiplier: *worker-multiplier
@@ -218,7 +218,7 @@ applications:
     annotations:
       gui-x: '500'
       gui-y: '0'
-    charm: cs:~openstack-charmers-next/eoan/keystone
+    charm: cs:~openstack-charmers-next/keystone
     num_units: 1
     options:
       worker-multiplier: *worker-multiplier
@@ -231,7 +231,7 @@ applications:
     annotations:
       gui-x: '500'
       gui-y: '500'
-    charm: cs:~openstack-charmers-next/eoan/neutron-api
+    charm: cs:~openstack-charmers-next/neutron-api
     num_units: 1
     options:
       neutron-security-groups: true
@@ -247,7 +247,7 @@ applications:
     annotations:
       gui-x: '0'
       gui-y: '500'
-    charm: cs:~openstack-charmers-next/eoan/placement
+    charm: cs:~openstack-charmers-next/placement
     num_units: 1
     options:
       worker-multiplier: *worker-multiplier
@@ -260,7 +260,7 @@ applications:
     annotations:
       gui-x: '0'
       gui-y: '500'
-    charm: cs:~openstack-charmers-next/eoan/nova-cloud-controller
+    charm: cs:~openstack-charmers-next/nova-cloud-controller
     num_units: 1
     options:
       network-manager: Neutron
@@ -272,7 +272,7 @@ applications:
     annotations:
       gui-x: '250'
       gui-y: '250'
-    charm: cs:~openstack-charmers-next/eoan/nova-compute
+    charm: cs:~openstack-charmers-next/nova-compute
     num_units: 3
     options:
       config-flags: default_ephemeral_format=ext4
@@ -297,7 +297,7 @@ applications:
     annotations:
       gui-x: '500'
       gui-y: '-250'
-    charm: cs:~openstack-charmers-next/eoan/openstack-dashboard
+    charm: cs:~openstack-charmers-next/openstack-dashboard
     num_units: 1
     options:
       openstack-origin: *openstack-origin
@@ -307,7 +307,7 @@ applications:
     annotations:
       gui-x: '500'
       gui-y: '250'
-    charm: cs:~openstack-charmers-next/eoan/rabbitmq-server
+    charm: cs:~openstack-charmers-next/rabbitmq-server
     num_units: 1
     to:
     - 'lxd:2'

--- a/development/openstack-base-eoan-train/bundle.yaml
+++ b/development/openstack-base-eoan-train/bundle.yaml
@@ -110,7 +110,7 @@ services:
     annotations:
       gui-x: '750'
       gui-y: '500'
-    charm: cs:~openstack-charmers-next/eoan/ceph-mon
+    charm: cs:~openstack-charmers-next/ceph-mon
     num_units: 3
     options:
       expected-osd-count: *expected-osd-count
@@ -124,7 +124,7 @@ services:
     annotations:
       gui-x: '1000'
       gui-y: '500'
-    charm: cs:~openstack-charmers-next/eoan/ceph-osd
+    charm: cs:~openstack-charmers-next/ceph-osd
     num_units: 3
     options:
       osd-devices: *osd-devices
@@ -137,7 +137,7 @@ services:
     annotations:
       gui-x: '1000'
       gui-y: '250'
-    charm: cs:~openstack-charmers-next/eoan/ceph-radosgw
+    charm: cs:~openstack-charmers-next/ceph-radosgw
     num_units: 1
     options:
       source: *openstack-origin
@@ -147,7 +147,7 @@ services:
     annotations:
       gui-x: '750'
       gui-y: '0'
-    charm: cs:~openstack-charmers-next/eoan/cinder
+    charm: cs:~openstack-charmers-next/cinder
     num_units: 1
     options:
       block-device: None
@@ -160,13 +160,13 @@ services:
     annotations:
       gui-x: '750'
       gui-y: '250'
-    charm: cs:~openstack-charmers-next/eoan/cinder-ceph
+    charm: cs:~openstack-charmers-next/cinder-ceph
     num_units: 0
   glance:
     annotations:
       gui-x: '250'
       gui-y: '0'
-    charm: cs:~openstack-charmers-next/eoan/glance
+    charm: cs:~openstack-charmers-next/glance
     num_units: 1
     options:
       worker-multiplier: *worker-multiplier
@@ -177,7 +177,7 @@ services:
     annotations:
       gui-x: '500'
       gui-y: '0'
-    charm: cs:~openstack-charmers-next/eoan/keystone
+    charm: cs:~openstack-charmers-next/keystone
     num_units: 1
     options:
       worker-multiplier: *worker-multiplier
@@ -188,7 +188,7 @@ services:
     annotations:
       gui-x: '0'
       gui-y: '250'
-    charm: cs:~openstack-charmers-next/eoan/percona-cluster
+    charm: cs:~openstack-charmers-next/percona-cluster
     num_units: 1
     options:
       max-connections: *mysql-connections
@@ -200,7 +200,7 @@ services:
     annotations:
       gui-x: '500'
       gui-y: '500'
-    charm: cs:~openstack-charmers-next/eoan/neutron-api
+    charm: cs:~openstack-charmers-next/neutron-api
     num_units: 1
     options:
       neutron-security-groups: true
@@ -213,7 +213,7 @@ services:
     annotations:
       gui-x: '0'
       gui-y: '500'
-    charm: cs:~openstack-charmers-next/eoan/placement
+    charm: cs:~openstack-charmers-next/placement
     num_units: 1
     options:
       worker-multiplier: *worker-multiplier
@@ -224,7 +224,7 @@ services:
     annotations:
       gui-x: '0'
       gui-y: '0'
-    charm: cs:~openstack-charmers-next/eoan/neutron-gateway
+    charm: cs:~openstack-charmers-next/neutron-gateway
     num_units: 1
     options:
       bridge-mappings: physnet1:br-ex
@@ -237,13 +237,13 @@ services:
     annotations:
       gui-x: '250'
       gui-y: '500'
-    charm: cs:~openstack-charmers-next/eoan/neutron-openvswitch
+    charm: cs:~openstack-charmers-next/neutron-openvswitch
     num_units: 0
   nova-cloud-controller:
     annotations:
       gui-x: '0'
       gui-y: '500'
-    charm: cs:~openstack-charmers-next/eoan/nova-cloud-controller
+    charm: cs:~openstack-charmers-next/nova-cloud-controller
     num_units: 1
     options:
       network-manager: Neutron
@@ -255,7 +255,7 @@ services:
     annotations:
       gui-x: '250'
       gui-y: '250'
-    charm: cs:~openstack-charmers-next/eoan/nova-compute
+    charm: cs:~openstack-charmers-next/nova-compute
     num_units: 3
     options:
       config-flags: default_ephemeral_format=ext4
@@ -278,7 +278,7 @@ services:
     annotations:
       gui-x: '500'
       gui-y: '-250'
-    charm: cs:~openstack-charmers-next/eoan/openstack-dashboard
+    charm: cs:~openstack-charmers-next/openstack-dashboard
     num_units: 1
     options:
       openstack-origin: *openstack-origin
@@ -288,7 +288,7 @@ services:
     annotations:
       gui-x: '500'
       gui-y: '250'
-    charm: cs:~openstack-charmers-next/eoan/rabbitmq-server
+    charm: cs:~openstack-charmers-next/rabbitmq-server
     num_units: 1
     to:
     - 'lxd:0'

--- a/development/openstack-base-jammy-yoga/bundle.yaml
+++ b/development/openstack-base-jammy-yoga/bundle.yaml
@@ -379,7 +379,7 @@ applications:
     - lxd:0
     - lxd:1
     - lxd:2
-    channel: yoga/edge
+    channel: 22.03/edge
   ovn-chassis:
     annotations:
       gui-x: '120'
@@ -391,7 +391,7 @@ applications:
     options:
       ovn-bridge-mappings: physnet1:br-ex
       bridge-interface-mappings: *data-port
-    channel: yoga/edge
+    channel: 22.03/edge
   vault-mysql-router:
     annotations:
       gui-x: '1535'

--- a/development/openstack-base-spaces/bundle.yaml
+++ b/development/openstack-base-spaces/bundle.yaml
@@ -86,7 +86,7 @@ services:
     annotations:
       gui-x: '750'
       gui-y: '500'
-    charm: cs:~openstack-charmers-next/xenial/ceph-mon
+    charm: cs:~openstack-charmers-next/ceph-mon
     num_units: 3
     options:
       expected-osd-count: 3
@@ -106,7 +106,7 @@ services:
     annotations:
       gui-x: '1000'
       gui-y: '500'
-    charm: cs:~openstack-charmers-next/xenial/ceph-osd
+    charm: cs:~openstack-charmers-next/ceph-osd
     num_units: 3
     options:
       osd-devices: /dev/sdb
@@ -122,7 +122,7 @@ services:
     annotations:
       gui-x: '1000'
       gui-y: '250'
-    charm: cs:~openstack-charmers-next/xenial/ceph-radosgw
+    charm: cs:~openstack-charmers-next/ceph-radosgw
     num_units: 1
     bindings:
       public: public
@@ -137,7 +137,7 @@ services:
     annotations:
       gui-x: '750'
       gui-y: '0'
-    charm: cs:~openstack-charmers-next/xenial/cinder
+    charm: cs:~openstack-charmers-next/cinder
     num_units: 1
     options:
       block-device: None
@@ -154,7 +154,7 @@ services:
     annotations:
       gui-x: '750'
       gui-y: '250'
-    charm: cs:~openstack-charmers-next/xenial/cinder-ceph
+    charm: cs:~openstack-charmers-next/cinder-ceph
     num_units: 0
     bindings:
       ceph: internal
@@ -164,7 +164,7 @@ services:
     annotations:
       gui-x: '250'
       gui-y: '0'
-    charm: cs:~openstack-charmers-next/xenial/glance
+    charm: cs:~openstack-charmers-next/glance
     num_units: 1
     bindings:
       public: public
@@ -178,7 +178,7 @@ services:
     annotations:
       gui-x: '500'
       gui-y: '0'
-    charm: cs:~openstack-charmers-next/xenial/keystone
+    charm: cs:~openstack-charmers-next/keystone
     num_units: 1
     options:
     bindings:
@@ -192,7 +192,7 @@ services:
     annotations:
       gui-x: '0'
       gui-y: '250'
-    charm: cs:~openstack-charmers-next/xenial/percona-cluster
+    charm: cs:~openstack-charmers-next/percona-cluster
     num_units: 1
     options:
       max-connections: 20000
@@ -204,7 +204,7 @@ services:
     annotations:
       gui-x: '500'
       gui-y: '500'
-    charm: cs:~openstack-charmers-next/xenial/neutron-api
+    charm: cs:~openstack-charmers-next/neutron-api
     num_units: 1
     options:
       neutron-security-groups: true
@@ -220,7 +220,7 @@ services:
     annotations:
       gui-x: '0'
       gui-y: '0'
-    charm: cs:~openstack-charmers-next/xenial/neutron-gateway
+    charm: cs:~openstack-charmers-next/neutron-gateway
     num_units: 1
     options:
       ext-port: eth1
@@ -233,7 +233,7 @@ services:
     annotations:
       gui-x: '250'
       gui-y: '500'
-    charm: cs:~openstack-charmers-next/xenial/neutron-openvswitch
+    charm: cs:~openstack-charmers-next/neutron-openvswitch
     num_units: 0
     bindings:
       data: data
@@ -242,7 +242,7 @@ services:
     annotations:
       gui-x: '0'
       gui-y: '500'
-    charm: cs:~openstack-charmers-next/xenial/nova-cloud-controller
+    charm: cs:~openstack-charmers-next/nova-cloud-controller
     num_units: 1
     options:
       network-manager: Neutron
@@ -258,7 +258,7 @@ services:
     annotations:
       gui-x: '250'
       gui-y: '250'
-    charm: cs:~openstack-charmers-next/xenial/nova-compute
+    charm: cs:~openstack-charmers-next/nova-compute
     num_units: 2
     options:
       config-flags: default_ephemeral_format=ext4
@@ -281,7 +281,7 @@ services:
     annotations:
       gui-x: '500'
       gui-y: '-250'
-    charm: cs:~openstack-charmers-next/xenial/openstack-dashboard
+    charm: cs:~openstack-charmers-next/openstack-dashboard
     num_units: 1
     bindings:
       website: internal
@@ -291,7 +291,7 @@ services:
     annotations:
       gui-x: '500'
       gui-y: '250'
-    charm: cs:~openstack-charmers-next/xenial/rabbitmq-server
+    charm: cs:~openstack-charmers-next/rabbitmq-server
     num_units: 1
     bindings:
       amqp: internal

--- a/development/openstack-base-xenial-mitaka/bundle.yaml
+++ b/development/openstack-base-xenial-mitaka/bundle.yaml
@@ -88,7 +88,7 @@ services:
     annotations:
       gui-x: '750'
       gui-y: '500'
-    charm: cs:~openstack-charmers-next/xenial/ceph-mon
+    charm: cs:~openstack-charmers-next/ceph-mon
     num_units: 3
     options:
       expected-osd-count: 3
@@ -100,7 +100,7 @@ services:
     annotations:
       gui-x: '1000'
       gui-y: '500'
-    charm: cs:~openstack-charmers-next/xenial/ceph-osd
+    charm: cs:~openstack-charmers-next/ceph-osd
     num_units: 3
     options:
       osd-devices: /dev/sdb
@@ -112,7 +112,7 @@ services:
     annotations:
       gui-x: '1000'
       gui-y: '250'
-    charm: cs:~openstack-charmers-next/xenial/ceph-radosgw
+    charm: cs:~openstack-charmers-next/ceph-radosgw
     num_units: 1
     to:
     - lxd:0
@@ -120,7 +120,7 @@ services:
     annotations:
       gui-x: '750'
       gui-y: '0'
-    charm: cs:~openstack-charmers-next/xenial/cinder
+    charm: cs:~openstack-charmers-next/cinder
     num_units: 1
     options:
       block-device: None
@@ -132,13 +132,13 @@ services:
     annotations:
       gui-x: '750'
       gui-y: '250'
-    charm: cs:~openstack-charmers-next/xenial/cinder-ceph
+    charm: cs:~openstack-charmers-next/cinder-ceph
     num_units: 0
   glance:
     annotations:
       gui-x: '250'
       gui-y: '0'
-    charm: cs:~openstack-charmers-next/xenial/glance
+    charm: cs:~openstack-charmers-next/glance
     num_units: 1
     options:
       worker-multiplier: 0.25
@@ -148,7 +148,7 @@ services:
     annotations:
       gui-x: '500'
       gui-y: '0'
-    charm: cs:~openstack-charmers-next/xenial/keystone
+    charm: cs:~openstack-charmers-next/keystone
     num_units: 1
     options:
       worker-multiplier: 0.25
@@ -158,7 +158,7 @@ services:
     annotations:
       gui-x: '0'
       gui-y: '250'
-    charm: cs:~openstack-charmers-next/xenial/percona-cluster
+    charm: cs:~openstack-charmers-next/percona-cluster
     num_units: 1
     options:
       max-connections: 1000
@@ -169,7 +169,7 @@ services:
     annotations:
       gui-x: '500'
       gui-y: '500'
-    charm: cs:~openstack-charmers-next/xenial/neutron-api
+    charm: cs:~openstack-charmers-next/neutron-api
     num_units: 1
     options:
       neutron-security-groups: true
@@ -181,7 +181,7 @@ services:
     annotations:
       gui-x: '0'
       gui-y: '0'
-    charm: cs:~openstack-charmers-next/xenial/neutron-gateway
+    charm: cs:~openstack-charmers-next/neutron-gateway
     num_units: 1
     options:
       bridge-mappings: physnet1:br-ex
@@ -193,13 +193,13 @@ services:
     annotations:
       gui-x: '250'
       gui-y: '500'
-    charm: cs:~openstack-charmers-next/xenial/neutron-openvswitch
+    charm: cs:~openstack-charmers-next/neutron-openvswitch
     num_units: 0
   nova-cloud-controller:
     annotations:
       gui-x: '0'
       gui-y: '500'
-    charm: cs:~openstack-charmers-next/xenial/nova-cloud-controller
+    charm: cs:~openstack-charmers-next/nova-cloud-controller
     num_units: 1
     options:
       network-manager: Neutron
@@ -210,7 +210,7 @@ services:
     annotations:
       gui-x: '250'
       gui-y: '250'
-    charm: cs:~openstack-charmers-next/xenial/nova-compute
+    charm: cs:~openstack-charmers-next/nova-compute
     num_units: 3
     options:
       config-flags: default_ephemeral_format=ext4
@@ -231,7 +231,7 @@ services:
     annotations:
       gui-x: '500'
       gui-y: '-250'
-    charm: cs:~openstack-charmers-next/xenial/openstack-dashboard
+    charm: cs:~openstack-charmers-next/openstack-dashboard
     num_units: 1
     to:
     - lxd:3
@@ -239,7 +239,7 @@ services:
     annotations:
       gui-x: '500'
       gui-y: '250'
-    charm: cs:~openstack-charmers-next/xenial/rabbitmq-server
+    charm: cs:~openstack-charmers-next/rabbitmq-server
     num_units: 1
     to:
     - lxd:0

--- a/development/openstack-base-xenial-newton/bundle.yaml
+++ b/development/openstack-base-xenial-newton/bundle.yaml
@@ -88,7 +88,7 @@ services:
     annotations:
       gui-x: '750'
       gui-y: '500'
-    charm: cs:~openstack-charmers-next/xenial/ceph-mon
+    charm: cs:~openstack-charmers-next/ceph-mon
     num_units: 3
     options:
       expected-osd-count: 3
@@ -100,7 +100,7 @@ services:
     annotations:
       gui-x: '1000'
       gui-y: '500'
-    charm: cs:~openstack-charmers-next/xenial/ceph-osd
+    charm: cs:~openstack-charmers-next/ceph-osd
     num_units: 3
     options:
       osd-devices: /dev/sdb
@@ -112,7 +112,7 @@ services:
     annotations:
       gui-x: '1000'
       gui-y: '250'
-    charm: cs:~openstack-charmers-next/xenial/ceph-radosgw
+    charm: cs:~openstack-charmers-next/ceph-radosgw
     num_units: 1
     to:
     - lxd:0
@@ -120,7 +120,7 @@ services:
     annotations:
       gui-x: '750'
       gui-y: '0'
-    charm: cs:~openstack-charmers-next/xenial/cinder
+    charm: cs:~openstack-charmers-next/cinder
     num_units: 1
     options:
       openstack-origin: cloud:xenial-newton
@@ -133,13 +133,13 @@ services:
     annotations:
       gui-x: '750'
       gui-y: '250'
-    charm: cs:~openstack-charmers-next/xenial/cinder-ceph
+    charm: cs:~openstack-charmers-next/cinder-ceph
     num_units: 0
   glance:
     annotations:
       gui-x: '250'
       gui-y: '0'
-    charm: cs:~openstack-charmers-next/xenial/glance
+    charm: cs:~openstack-charmers-next/glance
     num_units: 1
     options:
       openstack-origin: cloud:xenial-newton
@@ -150,7 +150,7 @@ services:
     annotations:
       gui-x: '500'
       gui-y: '0'
-    charm: cs:~openstack-charmers-next/xenial/keystone
+    charm: cs:~openstack-charmers-next/keystone
     num_units: 1
     options:
       openstack-origin: cloud:xenial-newton
@@ -161,7 +161,7 @@ services:
     annotations:
       gui-x: '0'
       gui-y: '250'
-    charm: cs:~openstack-charmers-next/xenial/percona-cluster
+    charm: cs:~openstack-charmers-next/percona-cluster
     num_units: 1
     options:
       max-connections: 1000
@@ -172,7 +172,7 @@ services:
     annotations:
       gui-x: '500'
       gui-y: '500'
-    charm: cs:~openstack-charmers-next/xenial/neutron-api
+    charm: cs:~openstack-charmers-next/neutron-api
     num_units: 1
     options:
       openstack-origin: cloud:xenial-newton
@@ -185,7 +185,7 @@ services:
     annotations:
       gui-x: '0'
       gui-y: '0'
-    charm: cs:~openstack-charmers-next/xenial/neutron-gateway
+    charm: cs:~openstack-charmers-next/neutron-gateway
     num_units: 1
     options:
       openstack-origin: cloud:xenial-newton
@@ -198,13 +198,13 @@ services:
     annotations:
       gui-x: '250'
       gui-y: '500'
-    charm: cs:~openstack-charmers-next/xenial/neutron-openvswitch
+    charm: cs:~openstack-charmers-next/neutron-openvswitch
     num_units: 0
   nova-cloud-controller:
     annotations:
       gui-x: '0'
       gui-y: '500'
-    charm: cs:~openstack-charmers-next/xenial/nova-cloud-controller
+    charm: cs:~openstack-charmers-next/nova-cloud-controller
     num_units: 1
     options:
       openstack-origin: cloud:xenial-newton
@@ -216,7 +216,7 @@ services:
     annotations:
       gui-x: '250'
       gui-y: '250'
-    charm: cs:~openstack-charmers-next/xenial/nova-compute
+    charm: cs:~openstack-charmers-next/nova-compute
     num_units: 3
     options:
       config-flags: default_ephemeral_format=ext4
@@ -238,7 +238,7 @@ services:
     annotations:
       gui-x: '500'
       gui-y: '-250'
-    charm: cs:~openstack-charmers-next/xenial/openstack-dashboard
+    charm: cs:~openstack-charmers-next/openstack-dashboard
     num_units: 1
     options:
       openstack-origin: cloud:xenial-newton
@@ -248,7 +248,7 @@ services:
     annotations:
       gui-x: '500'
       gui-y: '250'
-    charm: cs:~openstack-charmers-next/xenial/rabbitmq-server
+    charm: cs:~openstack-charmers-next/rabbitmq-server
     num_units: 1
     to:
     - lxd:0

--- a/development/openstack-base-xenial-ocata/bundle.yaml
+++ b/development/openstack-base-xenial-ocata/bundle.yaml
@@ -88,7 +88,7 @@ services:
     annotations:
       gui-x: '750'
       gui-y: '500'
-    charm: cs:~openstack-charmers-next/xenial/ceph-mon
+    charm: cs:~openstack-charmers-next/ceph-mon
     num_units: 3
     options:
       expected-osd-count: 3
@@ -100,7 +100,7 @@ services:
     annotations:
       gui-x: '1000'
       gui-y: '500'
-    charm: cs:~openstack-charmers-next/xenial/ceph-osd
+    charm: cs:~openstack-charmers-next/ceph-osd
     num_units: 3
     options:
       osd-devices: /dev/sdb
@@ -112,7 +112,7 @@ services:
     annotations:
       gui-x: '1000'
       gui-y: '250'
-    charm: cs:~openstack-charmers-next/xenial/ceph-radosgw
+    charm: cs:~openstack-charmers-next/ceph-radosgw
     num_units: 1
     to:
     - lxd:0
@@ -120,7 +120,7 @@ services:
     annotations:
       gui-x: '750'
       gui-y: '0'
-    charm: cs:~openstack-charmers-next/xenial/cinder
+    charm: cs:~openstack-charmers-next/cinder
     num_units: 1
     options:
       openstack-origin: cloud:xenial-ocata
@@ -133,13 +133,13 @@ services:
     annotations:
       gui-x: '750'
       gui-y: '250'
-    charm: cs:~openstack-charmers-next/xenial/cinder-ceph
+    charm: cs:~openstack-charmers-next/cinder-ceph
     num_units: 0
   glance:
     annotations:
       gui-x: '250'
       gui-y: '0'
-    charm: cs:~openstack-charmers-next/xenial/glance
+    charm: cs:~openstack-charmers-next/glance
     num_units: 1
     options:
       openstack-origin: cloud:xenial-ocata
@@ -150,7 +150,7 @@ services:
     annotations:
       gui-x: '500'
       gui-y: '0'
-    charm: cs:~openstack-charmers-next/xenial/keystone
+    charm: cs:~openstack-charmers-next/keystone
     num_units: 1
     options:
       openstack-origin: cloud:xenial-ocata
@@ -161,7 +161,7 @@ services:
     annotations:
       gui-x: '0'
       gui-y: '250'
-    charm: cs:~openstack-charmers-next/xenial/percona-cluster
+    charm: cs:~openstack-charmers-next/percona-cluster
     num_units: 1
     options:
       max-connections: 1000
@@ -172,7 +172,7 @@ services:
     annotations:
       gui-x: '500'
       gui-y: '500'
-    charm: cs:~openstack-charmers-next/xenial/neutron-api
+    charm: cs:~openstack-charmers-next/neutron-api
     num_units: 1
     options:
       openstack-origin: cloud:xenial-ocata
@@ -185,7 +185,7 @@ services:
     annotations:
       gui-x: '0'
       gui-y: '0'
-    charm: cs:~openstack-charmers-next/xenial/neutron-gateway
+    charm: cs:~openstack-charmers-next/neutron-gateway
     num_units: 1
     options:
       openstack-origin: cloud:xenial-ocata
@@ -198,13 +198,13 @@ services:
     annotations:
       gui-x: '250'
       gui-y: '500'
-    charm: cs:~openstack-charmers-next/xenial/neutron-openvswitch
+    charm: cs:~openstack-charmers-next/neutron-openvswitch
     num_units: 0
   nova-cloud-controller:
     annotations:
       gui-x: '0'
       gui-y: '500'
-    charm: cs:~openstack-charmers-next/xenial/nova-cloud-controller
+    charm: cs:~openstack-charmers-next/nova-cloud-controller
     num_units: 1
     options:
       openstack-origin: cloud:xenial-ocata
@@ -216,7 +216,7 @@ services:
     annotations:
       gui-x: '250'
       gui-y: '250'
-    charm: cs:~openstack-charmers-next/xenial/nova-compute
+    charm: cs:~openstack-charmers-next/nova-compute
     num_units: 3
     options:
       config-flags: default_ephemeral_format=ext4
@@ -238,7 +238,7 @@ services:
     annotations:
       gui-x: '500'
       gui-y: '-250'
-    charm: cs:~openstack-charmers-next/xenial/openstack-dashboard
+    charm: cs:~openstack-charmers-next/openstack-dashboard
     num_units: 1
     options:
       openstack-origin: cloud:xenial-ocata
@@ -248,7 +248,7 @@ services:
     annotations:
       gui-x: '500'
       gui-y: '250'
-    charm: cs:~openstack-charmers-next/xenial/rabbitmq-server
+    charm: cs:~openstack-charmers-next/rabbitmq-server
     num_units: 1
     to:
     - lxd:0

--- a/development/openstack-base-xenial-pike/bundle.yaml
+++ b/development/openstack-base-xenial-pike/bundle.yaml
@@ -88,7 +88,7 @@ services:
     annotations:
       gui-x: '750'
       gui-y: '500'
-    charm: cs:~openstack-charmers-next/xenial/ceph-mon
+    charm: cs:~openstack-charmers-next/ceph-mon
     num_units: 3
     options:
       expected-osd-count: 3
@@ -101,7 +101,7 @@ services:
     annotations:
       gui-x: '1000'
       gui-y: '500'
-    charm: cs:~openstack-charmers-next/xenial/ceph-osd
+    charm: cs:~openstack-charmers-next/ceph-osd
     num_units: 3
     options:
       osd-devices: /dev/sdb
@@ -114,7 +114,7 @@ services:
     annotations:
       gui-x: '1000'
       gui-y: '250'
-    charm: cs:~openstack-charmers-next/xenial/ceph-radosgw
+    charm: cs:~openstack-charmers-next/ceph-radosgw
     num_units: 1
     options:
       source: cloud:xenial-pike
@@ -124,7 +124,7 @@ services:
     annotations:
       gui-x: '750'
       gui-y: '0'
-    charm: cs:~openstack-charmers-next/xenial/cinder
+    charm: cs:~openstack-charmers-next/cinder
     num_units: 1
     options:
       openstack-origin: cloud:xenial-pike
@@ -137,13 +137,13 @@ services:
     annotations:
       gui-x: '750'
       gui-y: '250'
-    charm: cs:~openstack-charmers-next/xenial/cinder-ceph
+    charm: cs:~openstack-charmers-next/cinder-ceph
     num_units: 0
   glance:
     annotations:
       gui-x: '250'
       gui-y: '0'
-    charm: cs:~openstack-charmers-next/xenial/glance
+    charm: cs:~openstack-charmers-next/glance
     num_units: 1
     options:
       openstack-origin: cloud:xenial-pike
@@ -154,7 +154,7 @@ services:
     annotations:
       gui-x: '500'
       gui-y: '0'
-    charm: cs:~openstack-charmers-next/xenial/keystone
+    charm: cs:~openstack-charmers-next/keystone
     num_units: 1
     options:
       openstack-origin: cloud:xenial-pike
@@ -165,7 +165,7 @@ services:
     annotations:
       gui-x: '0'
       gui-y: '250'
-    charm: cs:~openstack-charmers-next/xenial/percona-cluster
+    charm: cs:~openstack-charmers-next/percona-cluster
     num_units: 1
     options:
       max-connections: 1000
@@ -176,7 +176,7 @@ services:
     annotations:
       gui-x: '500'
       gui-y: '500'
-    charm: cs:~openstack-charmers-next/xenial/neutron-api
+    charm: cs:~openstack-charmers-next/neutron-api
     num_units: 1
     options:
       openstack-origin: cloud:xenial-pike
@@ -189,7 +189,7 @@ services:
     annotations:
       gui-x: '0'
       gui-y: '0'
-    charm: cs:~openstack-charmers-next/xenial/neutron-gateway
+    charm: cs:~openstack-charmers-next/neutron-gateway
     num_units: 1
     options:
       openstack-origin: cloud:xenial-pike
@@ -202,13 +202,13 @@ services:
     annotations:
       gui-x: '250'
       gui-y: '500'
-    charm: cs:~openstack-charmers-next/xenial/neutron-openvswitch
+    charm: cs:~openstack-charmers-next/neutron-openvswitch
     num_units: 0
   nova-cloud-controller:
     annotations:
       gui-x: '0'
       gui-y: '500'
-    charm: cs:~openstack-charmers-next/xenial/nova-cloud-controller
+    charm: cs:~openstack-charmers-next/nova-cloud-controller
     num_units: 1
     options:
       openstack-origin: cloud:xenial-pike
@@ -220,7 +220,7 @@ services:
     annotations:
       gui-x: '250'
       gui-y: '250'
-    charm: cs:~openstack-charmers-next/xenial/nova-compute
+    charm: cs:~openstack-charmers-next/nova-compute
     num_units: 3
     options:
       config-flags: default_ephemeral_format=ext4
@@ -242,7 +242,7 @@ services:
     annotations:
       gui-x: '500'
       gui-y: '-250'
-    charm: cs:~openstack-charmers-next/xenial/openstack-dashboard
+    charm: cs:~openstack-charmers-next/openstack-dashboard
     num_units: 1
     options:
       openstack-origin: cloud:xenial-pike
@@ -252,7 +252,7 @@ services:
     annotations:
       gui-x: '500'
       gui-y: '250'
-    charm: cs:~openstack-charmers-next/xenial/rabbitmq-server
+    charm: cs:~openstack-charmers-next/rabbitmq-server
     num_units: 1
     to:
     - lxd:0

--- a/development/openstack-base-xenial-queens/bundle.yaml
+++ b/development/openstack-base-xenial-queens/bundle.yaml
@@ -88,7 +88,7 @@ services:
     annotations:
       gui-x: '750'
       gui-y: '500'
-    charm: cs:~openstack-charmers-next/xenial/ceph-mon
+    charm: cs:~openstack-charmers-next/ceph-mon
     num_units: 3
     options:
       expected-osd-count: 3
@@ -101,7 +101,7 @@ services:
     annotations:
       gui-x: '1000'
       gui-y: '500'
-    charm: cs:~openstack-charmers-next/xenial/ceph-osd
+    charm: cs:~openstack-charmers-next/ceph-osd
     num_units: 3
     options:
       osd-devices: /dev/sdb
@@ -114,7 +114,7 @@ services:
     annotations:
       gui-x: '1000'
       gui-y: '250'
-    charm: cs:~openstack-charmers-next/xenial/ceph-radosgw
+    charm: cs:~openstack-charmers-next/ceph-radosgw
     num_units: 1
     options:
       source: cloud:xenial-queens
@@ -124,7 +124,7 @@ services:
     annotations:
       gui-x: '750'
       gui-y: '0'
-    charm: cs:~openstack-charmers-next/xenial/cinder
+    charm: cs:~openstack-charmers-next/cinder
     num_units: 1
     options:
       openstack-origin: cloud:xenial-queens
@@ -137,13 +137,13 @@ services:
     annotations:
       gui-x: '750'
       gui-y: '250'
-    charm: cs:~openstack-charmers-next/xenial/cinder-ceph
+    charm: cs:~openstack-charmers-next/cinder-ceph
     num_units: 0
   glance:
     annotations:
       gui-x: '250'
       gui-y: '0'
-    charm: cs:~openstack-charmers-next/xenial/glance
+    charm: cs:~openstack-charmers-next/glance
     num_units: 1
     options:
       openstack-origin: cloud:xenial-queens
@@ -154,7 +154,7 @@ services:
     annotations:
       gui-x: '500'
       gui-y: '0'
-    charm: cs:~openstack-charmers-next/xenial/keystone
+    charm: cs:~openstack-charmers-next/keystone
     num_units: 1
     options:
       openstack-origin: cloud:xenial-queens
@@ -165,7 +165,7 @@ services:
     annotations:
       gui-x: '0'
       gui-y: '250'
-    charm: cs:~openstack-charmers-next/xenial/percona-cluster
+    charm: cs:~openstack-charmers-next/percona-cluster
     num_units: 1
     options:
       max-connections: 1000
@@ -176,7 +176,7 @@ services:
     annotations:
       gui-x: '500'
       gui-y: '500'
-    charm: cs:~openstack-charmers-next/xenial/neutron-api
+    charm: cs:~openstack-charmers-next/neutron-api
     num_units: 1
     options:
       openstack-origin: cloud:xenial-queens
@@ -189,7 +189,7 @@ services:
     annotations:
       gui-x: '0'
       gui-y: '0'
-    charm: cs:~openstack-charmers-next/xenial/neutron-gateway
+    charm: cs:~openstack-charmers-next/neutron-gateway
     num_units: 1
     options:
       openstack-origin: cloud:xenial-queens
@@ -202,13 +202,13 @@ services:
     annotations:
       gui-x: '250'
       gui-y: '500'
-    charm: cs:~openstack-charmers-next/xenial/neutron-openvswitch
+    charm: cs:~openstack-charmers-next/neutron-openvswitch
     num_units: 0
   nova-cloud-controller:
     annotations:
       gui-x: '0'
       gui-y: '500'
-    charm: cs:~openstack-charmers-next/xenial/nova-cloud-controller
+    charm: cs:~openstack-charmers-next/nova-cloud-controller
     num_units: 1
     options:
       openstack-origin: cloud:xenial-queens
@@ -220,7 +220,7 @@ services:
     annotations:
       gui-x: '250'
       gui-y: '250'
-    charm: cs:~openstack-charmers-next/xenial/nova-compute
+    charm: cs:~openstack-charmers-next/nova-compute
     num_units: 3
     options:
       config-flags: default_ephemeral_format=ext4
@@ -242,7 +242,7 @@ services:
     annotations:
       gui-x: '500'
       gui-y: '-250'
-    charm: cs:~openstack-charmers-next/xenial/openstack-dashboard
+    charm: cs:~openstack-charmers-next/openstack-dashboard
     num_units: 1
     options:
       openstack-origin: cloud:xenial-queens
@@ -252,7 +252,7 @@ services:
     annotations:
       gui-x: '500'
       gui-y: '250'
-    charm: cs:~openstack-charmers-next/xenial/rabbitmq-server
+    charm: cs:~openstack-charmers-next/rabbitmq-server
     num_units: 1
     options:
       source: cloud:xenial-queens

--- a/development/openstack-ha/masakari-mosci.yaml
+++ b/development/openstack-ha/masakari-mosci.yaml
@@ -232,7 +232,7 @@ services:
     annotations:
       gui-x: '0'
       gui-y: '500'
-    charm: cs:~openstack-charmers-next/bionic/placement
+    charm: cs:~openstack-charmers-next/placement
     num_units: 3
     options:
       worker-multiplier: *worker-multiplier

--- a/development/openstack-refstack-xenial-ocata-ppc64el-alt/bundle.yaml
+++ b/development/openstack-refstack-xenial-ocata-ppc64el-alt/bundle.yaml
@@ -209,9 +209,8 @@ services:
     annotations:
       gui-x: '0'
       gui-y: '250'
-    charm: cs:mysql
-    # Work-around for https://bugs.launchpad.net/ubuntu/+source/percona-xtradb-cluster-5.5/+bug/1657256
-    # charm: cs:~openstack-charmers-next/xenial/percona-cluster
+    # charm: cs:mysql
+    charm: cs:~openstack-charmers-next/percona-cluster
     num_units: 1
     options:
       max-connections: 1000

--- a/development/openstack-refstack-xenial-pike-ppc64el-alt/bundle.yaml
+++ b/development/openstack-refstack-xenial-pike-ppc64el-alt/bundle.yaml
@@ -211,9 +211,8 @@ services:
     annotations:
       gui-x: '0'
       gui-y: '250'
-    charm: cs:mysql
-    # Work-around for https://bugs.launchpad.net/ubuntu/+source/percona-xtradb-cluster-5.5/+bug/1657256
-    # charm: cs:~openstack-charmers-next/xenial/percona-cluster
+    # charm: cs:mysql
+    charm: cs:~openstack-charmers-next/percona-cluster
     num_units: 1
     options:
       max-connections: 1000

--- a/development/openstack-telemetry-bionic-train/bundle.yaml
+++ b/development/openstack-telemetry-bionic-train/bundle.yaml
@@ -253,7 +253,7 @@ services:
     annotations:
       gui-x: '0'
       gui-y: '500'
-    charm: cs:~openstack-charmers-next/bionic/placement
+    charm: cs:~openstack-charmers-next/placement
     num_units: 1
     options:
       worker-multiplier: *worker-multiplier

--- a/development/openstack-telemetry-bionic-ussuri/bundle.yaml
+++ b/development/openstack-telemetry-bionic-ussuri/bundle.yaml
@@ -253,7 +253,7 @@ services:
     annotations:
       gui-x: '0'
       gui-y: '500'
-    charm: cs:~openstack-charmers-next/bionic/placement
+    charm: cs:~openstack-charmers-next/placement
     num_units: 1
     options:
       worker-multiplier: *worker-multiplier


### PR DESCRIPTION
Previously, charm urls could reference Ubuntu series as part of the
charm that was being delivered (e.g. <team>/<series>/<charm>). Some
of the legacy bundles in this repository used this particular URL
schema to target specific series of charms.

However, this was deprecated as the series was added to the charm
metadata and the new charmhub store does not support this particular
API and subsequently causes the lint tests to fail as a result.

This removes all of these urls from the bundles in order to allow
the lint checks to pass.

Signed-off-by: Billy Olsen <billy.olsen@gmail.com>