### PR TITLE
Charmhub migration

### DIFF
--- a/development/ceph-base-focal-quincy/README.md
+++ b/development/ceph-base-focal-quincy/README.md
@@ -1,0 +1,45 @@
+# Basic Ceph Cluster
+
+*DEV/TEST ONLY*: This unstable, development example bundle deploys a Ceph (Quincy) cluster on Ubuntu 20.04 LTS. See also: [Stable Bundles](https://jujucharms.com/u/openstack-charmers).
+
+Ceph is often used with [OpenStack].
+
+## Requirements
+
+This example bundle is designed to run on bare metal using Juju with [MAAS][] (Metal-as-a-Service); you will need to have setup a [MAAS][] deployment with a minimum of 3 physical servers prior to using this bundle.
+
+Certain configuration options within the bundle may need to be adjusted prior to deployment to fit your particular set of hardware. For example, network device names and block device names can vary.
+
+Servers should have:
+
+ - A minimum of 8GB of physical RAM.
+ - Enough CPU cores to support your capacity requirements.
+ - Two disks (identified by /dev/sda and /dev/sdb); the first is used by MAAS for the OS install, the second for Ceph storage.
+
+## Components
+ - 3 Nodes for Ceph OSDs
+ - 3 Ceph monitors in LXD containers on the OSD machines
+
+All physical servers (not LXD containers) will also have NTP installed and configured to keep time in sync.
+
+To horizontally scale Ceph:
+
+    juju add-unit ceph-osd # Add one more unit
+    juju add-unit -n50 ceph-osd # add 50 more units
+
+## Ensuring it's working
+
+To ensure your cluster is functioning correctly, run through the following commands.
+
+Connect to a monitor shell:
+
+    juju ssh ceph-mon/0
+
+Check that the cluster is healthy:
+
+    sudo ceph -s
+
+<!-- LINKS -->
+
+[MAAS]: https://maas.io/
+[OpenStack]: https://ubuntu.com/openstack/what-is-openstack

--- a/development/ceph-base-focal-quincy/bundle.yaml
+++ b/development/ceph-base-focal-quincy/bundle.yaml
@@ -20,7 +20,7 @@ applications:
     num_units: 3
     options:
       expected-osd-count: 3
-      source: distro
+      source: cloud:focal-yoga
     to:
     - lxd:0
     - lxd:1
@@ -34,7 +34,7 @@ applications:
     num_units: 3
     options:
       osd-devices: /dev/sdb
-      source: distro
+      source: cloud:focal-yoga
     to:
     - '0'
     - '1'

--- a/development/ceph-base-focal-quincy/bundle.yaml
+++ b/development/ceph-base-focal-quincy/bundle.yaml
@@ -1,0 +1,41 @@
+name: ceph-base
+machines:
+  '0':
+    series: focal
+  '1':
+    series: focal
+  '2':
+    series: focal
+relations:
+- - ceph-osd:mon
+  - ceph-mon:osd
+series: focal
+applications:
+  ceph-mon:
+    annotations:
+      gui-x: '750'
+      gui-y: '500'
+    charm: ch:ceph-mon
+    channel: quincy/edge
+    num_units: 3
+    options:
+      expected-osd-count: 3
+      source: distro
+    to:
+    - lxd:0
+    - lxd:1
+    - lxd:2
+  ceph-osd:
+    annotations:
+      gui-x: '1000'
+      gui-y: '500'
+    charm: ch:ceph-osd
+    channel: quincy/edge
+    num_units: 3
+    options:
+      osd-devices: /dev/sdb
+      source: distro
+    to:
+    - '0'
+    - '1'
+    - '2'

--- a/development/ceph-base-focal-quincy/charmcraft.yaml
+++ b/development/ceph-base-focal-quincy/charmcraft.yaml
@@ -1,0 +1,14 @@
+type: bundle
+
+parts:
+  bundle:
+    prime:
+      - bundle.yaml
+      - README.md
+      - repo-info
+      - test-requirements.txt
+      - tests/bundles/bundle.yaml
+      - tests/bundles/overlays/bundle.yaml.j2
+      - tests/tests.yaml
+      - tox.ini
+      - validate-ceph.sh

--- a/development/ceph-base-focal-quincy/test-requirements.txt
+++ b/development/ceph-base-focal-quincy/test-requirements.txt
@@ -1,0 +1,1 @@
+../shared/test-requirements.txt

--- a/development/ceph-base-focal-quincy/tests/bundles/bundle.yaml
+++ b/development/ceph-base-focal-quincy/tests/bundles/bundle.yaml
@@ -1,0 +1,1 @@
+../../bundle.yaml

--- a/development/ceph-base-focal-quincy/tests/bundles/overlays/bundle.yaml.j2
+++ b/development/ceph-base-focal-quincy/tests/bundles/overlays/bundle.yaml.j2
@@ -1,0 +1,1 @@
+../../../../overlays/ceph-base-virt-overlay.yaml

--- a/development/ceph-base-focal-quincy/tests/tests.yaml
+++ b/development/ceph-base-focal-quincy/tests/tests.yaml
@@ -1,0 +1,11 @@
+configure: []
+dev_bundles: []
+gate_bundles:
+  - bundle
+smoke_bundles: []
+tests:
+  - zaza.openstack.charm_tests.ceph.osd.tests.SecurityTest
+  - zaza.openstack.charm_tests.ceph.osd.tests.ServiceTest
+tests_options:
+  force_deploy:
+    - bundle

--- a/development/ceph-base-focal-quincy/tox.ini
+++ b/development/ceph-base-focal-quincy/tox.ini
@@ -1,0 +1,1 @@
+../shared/tox.ini

--- a/development/ceph-base-focal-quincy/validate-ceph.sh
+++ b/development/ceph-base-focal-quincy/validate-ceph.sh
@@ -1,0 +1,1 @@
+../shared/validate-ceph.sh

--- a/development/ceph-base-jammy-quincy/bundle.yaml
+++ b/development/ceph-base-jammy-quincy/bundle.yaml
@@ -1,3 +1,4 @@
+name: ceph-base
 machines:
   '0':
     series: jammy

--- a/development/ceph-base-jammy-quincy/charmcraft.yaml
+++ b/development/ceph-base-jammy-quincy/charmcraft.yaml
@@ -1,0 +1,14 @@
+type: bundle
+
+parts:
+  bundle:
+    prime:
+      - bundle.yaml
+      - README.md
+      - repo-info
+      - test-requirements.txt
+      - tests/bundles/bundle.yaml
+      - tests/bundles/overlays/bundle.yaml.j2
+      - tests/tests.yaml
+      - tox.ini
+      - validate-ceph.sh

--- a/development/openstack-base-focal-yoga/bundle.yaml
+++ b/development/openstack-base-focal-yoga/bundle.yaml
@@ -6,7 +6,7 @@
 #       Refer to the [Open Virtual Network (OVN)](https://docs.openstack.org/project-deploy-guide/charm-deployment-guide/latest/app-ovn.html)
 #       section of the [OpenStack Charms Deployment Guide](https://docs.openstack.org/project-deploy-guide/charm-deployment-guide/latest/)
 #       for more information.
-
+name: openstack-base
 series: focal
 variables:
   openstack-origin: &openstack-origin cloud:focal-yoga

--- a/development/openstack-base-focal-yoga/charmcraft.yaml
+++ b/development/openstack-base-focal-yoga/charmcraft.yaml
@@ -1,0 +1,16 @@
+type: bundle
+
+parts:
+  bundle:
+    prime:
+      - bundle.yaml
+      - openrc
+      - openrcv3_domain
+      - openrcv3_project
+      - openstack-base-spaces-overlay.yaml
+      - README.md
+      - test-requirements.txt
+      - tests/bundles/bundle.yaml
+      - tests/bundles/overlays/bundle.yaml.j2
+      - tests/tests.yaml
+      - tox.ini

--- a/development/openstack-base-jammy-yoga/bundle.yaml
+++ b/development/openstack-base-jammy-yoga/bundle.yaml
@@ -8,7 +8,7 @@ local_overlay_enabled: False
 #       Refer to the [Open Virtual Network (OVN)](https://docs.openstack.org/project-deploy-guide/charm-deployment-guide/latest/app-ovn.html)
 #       section of the [OpenStack Charms Deployment Guide](https://docs.openstack.org/project-deploy-guide/charm-deployment-guide/latest/)
 #       for more information.
-
+name: openstack-base
 series: jammy
 variables:
   openstack-origin: &openstack-origin distro

--- a/development/openstack-base-jammy-yoga/charmcraft.yaml
+++ b/development/openstack-base-jammy-yoga/charmcraft.yaml
@@ -1,0 +1,16 @@
+type: bundle
+
+parts:
+  bundle:
+    prime:
+      - bundle.yaml
+      - openrc
+      - openrcv3_domain
+      - openrcv3_project
+      - openstack-base-spaces-overlay.yaml
+      - README.md
+      - test-requirements.txt
+      - tests/bundles/bundle.yaml
+      - tests/bundles/overlays/bundle.yaml.j2
+      - tests/tests.yaml
+      - tox.ini

--- a/development/openstack-telemetry-focal-yoga/bundle.yaml
+++ b/development/openstack-telemetry-focal-yoga/bundle.yaml
@@ -6,7 +6,7 @@
 #       Refer to the [Open Virtual Network (OVN)](https://docs.openstack.org/project-deploy-guide/charm-deployment-guide/latest/app-ovn.html)
 #       section of the [OpenStack Charms Deployment Guide](https://docs.openstack.org/project-deploy-guide/charm-deployment-guide/latest/)
 #       for more information.
-
+name: openstack-telemetry
 local_overlay_enabled: true
 series: focal
 variables:

--- a/development/openstack-telemetry-focal-yoga/bundle.yaml
+++ b/development/openstack-telemetry-focal-yoga/bundle.yaml
@@ -192,7 +192,7 @@ applications:
     channel: yoga/edge
   aodh-mysql-router:
     charm: ch:mysql-router
-    channel: 8.0.19/edge
+    channel: 8.0/edge
   ceilometer:
     annotations:
       gui-x: '1250'
@@ -256,7 +256,7 @@ applications:
       gui-x: '900'
       gui-y: '1400'
     charm: ch:mysql-router
-    channel: 8.0.19/edge
+    channel: 8.0/edge
   cinder:
     annotations:
       gui-x: '980'
@@ -283,7 +283,7 @@ applications:
       gui-x: '-290'
       gui-y: '1400'
     charm: ch:mysql-router
-    channel: 8.0.19/edge
+    channel: 8.0/edge
   glance:
     annotations:
       gui-x: '-230'
@@ -301,7 +301,7 @@ applications:
       gui-x: '230'
       gui-y: '1400'
     charm: ch:mysql-router
-    channel: 8.0.19/edge
+    channel: 8.0/edge
   keystone:
     annotations:
       gui-x: '300'
@@ -319,7 +319,7 @@ applications:
       gui-x: '505'
       gui-y: '1385'
     charm: ch:mysql-router
-    channel: 8.0.19/edge
+    channel: 8.0/edge
   neutron-api-plugin-ovn:
     annotations:
       gui-x: '690'
@@ -345,7 +345,7 @@ applications:
       gui-x: '1320'
       gui-y: '1385'
     charm: ch:mysql-router
-    channel: 8.0.19/edge
+    channel: 8.0/edge
   placement:
     annotations:
       gui-x: '1320'
@@ -363,7 +363,7 @@ applications:
       gui-x: '-30'
       gui-y: '1385'
     charm: ch:mysql-router
-    channel: 8.0.19/edge
+    channel: 8.0/edge
   nova-cloud-controller:
     annotations:
       gui-x: '35'
@@ -405,7 +405,7 @@ applications:
       gui-x: '510'
       gui-y: '1030'
     charm: ch:mysql-router
-    channel: 8.0.19/edge
+    channel: 8.0/edge
   openstack-dashboard:
     annotations:
       gui-x: '585'
@@ -436,7 +436,7 @@ applications:
     - lxd:0
     - lxd:1
     - lxd:2
-    channel: 8.0.19/edge
+    channel: 8.0/edge
   ovn-central:
     annotations:
       gui-x: '70'
@@ -467,7 +467,7 @@ applications:
       gui-x: '1535'
       gui-y: '1560'
     charm: ch:mysql-router
-    channel: 8.0.19/edge
+    channel: 8.0/edge
   vault:
     annotations:
       gui-x: '1610'
@@ -490,7 +490,7 @@ applications:
     channel: yoga/edge
   gnocchi-mysql-router:
     charm: ch:mysql-router
-    channel: 8.0.19/edge
+    channel: 8.0/edge
   memcached:
     series: bionic
     annotations:

--- a/development/openstack-telemetry-focal-yoga/charmcraft.yaml
+++ b/development/openstack-telemetry-focal-yoga/charmcraft.yaml
@@ -1,0 +1,12 @@
+type: bundle
+
+parts:
+  bundle:
+    prime:
+      - bundle.yaml
+      - openrc
+      - openrcv3_domain
+      - openrcv3_project
+      - openstack-telemetry-spaces-overlay.yaml
+      - README.md
+      - repo-info

--- a/development/openstack-telemetry-jammy-yoga/bundle.yaml
+++ b/development/openstack-telemetry-jammy-yoga/bundle.yaml
@@ -6,7 +6,7 @@
 #       Refer to the [Open Virtual Network (OVN)](https://docs.openstack.org/project-deploy-guide/charm-deployment-guide/latest/app-ovn.html)
 #       section of the [OpenStack Charms Deployment Guide](https://docs.openstack.org/project-deploy-guide/charm-deployment-guide/latest/)
 #       for more information.
-
+name: openstack-telemetry
 local_overlay_enabled: true
 series: jammy
 variables:

--- a/development/openstack-telemetry-jammy-yoga/charmcraft.yaml
+++ b/development/openstack-telemetry-jammy-yoga/charmcraft.yaml
@@ -1,0 +1,12 @@
+type: bundle
+
+parts:
+  bundle:
+    prime:
+      - bundle.yaml
+      - openrc
+      - openrcv3_domain
+      - openrcv3_project
+      - openstack-telemetry-spaces-overlay.yaml
+      - README.md
+      - repo-info

--- a/stable/ceph-base/README.md
+++ b/stable/ceph-base/README.md
@@ -1,6 +1,6 @@
 # Basic Ceph Cluster
 
-This example bundle deploys a Ceph (Octopus) cluster on Ubuntu 20.04 LTS.
+This example bundle deploys a Ceph (Quincy) cluster on Ubuntu 20.04 LTS.
 
 ## Requirements
 

--- a/stable/ceph-base/bundle.yaml
+++ b/stable/ceph-base/bundle.yaml
@@ -16,11 +16,11 @@ applications:
       gui-x: '750'
       gui-y: '500'
     charm: ch:ceph-mon
-    channel: quincy/edge
+    channel: quincy/stable
     num_units: 3
     options:
       expected-osd-count: 3
-      source: distro
+      source: cloud:focal-yoga
     to:
     - lxd:0
     - lxd:1
@@ -30,11 +30,11 @@ applications:
       gui-x: '1000'
       gui-y: '500'
     charm: ch:ceph-osd
-    channel: quincy/edge
+    channel: quincy/stable
     num_units: 3
     options:
       osd-devices: /dev/sdb
-      source: distro
+      source: cloud:focal-yoga
     to:
     - '0'
     - '1'

--- a/stable/ceph-base/bundle.yaml
+++ b/stable/ceph-base/bundle.yaml
@@ -1,3 +1,4 @@
+name: ceph-base
 machines:
   '0':
     series: focal
@@ -9,12 +10,13 @@ relations:
 - - ceph-osd:mon
   - ceph-mon:osd
 series: focal
-services:
+applications:
   ceph-mon:
     annotations:
       gui-x: '750'
       gui-y: '500'
-    charm: cs:ceph-mon-61
+    charm: ch:ceph-mon
+    channel: quincy/edge
     num_units: 3
     options:
       expected-osd-count: 3
@@ -27,7 +29,8 @@ services:
     annotations:
       gui-x: '1000'
       gui-y: '500'
-    charm: cs:ceph-osd-315
+    charm: ch:ceph-osd
+    channel: quincy/edge
     num_units: 3
     options:
       osd-devices: /dev/sdb

--- a/stable/ceph-base/charmcraft.yaml
+++ b/stable/ceph-base/charmcraft.yaml
@@ -1,0 +1,14 @@
+type: bundle
+
+parts:
+  bundle:
+    prime:
+      - bundle.yaml
+      - README.md
+      - repo-info
+      - test-requirements.txt
+      - tests/bundles/bundle.yaml
+      - tests/bundles/overlays/bundle.yaml.j2
+      - tests/tests.yaml
+      - tox.ini
+      - validate-ceph.sh

--- a/stable/openstack-base/README.md
+++ b/stable/openstack-base/README.md
@@ -4,8 +4,8 @@ This `openstack-base` bundle deploys a base OpenStack cloud. Its major elements
 include:
 
 * Ubuntu 20.04 LTS (Focal)
-* OpenStack Xena
-* Ceph Pacific
+* OpenStack Yoga
+* Ceph Quincy
 
 Cloud services consist of Compute, Network, Block Storage, Object Storage,
 Identity, Image, and Dashboard.
@@ -36,6 +36,9 @@ The MAAS cluster must have a minimum of four nodes:
   The first network interface is used for communication between cloud services
   (East/West traffic), and the second is for network traffic between the cloud
   and all external networks (North/South traffic).
+
+> **Pro tip**: A single network interface will suffice if an Open vSwitch
+  bridge is used on each of the nodes (MAAS v.2.9.2 required).
 
 > **Note**: The smaller controller node can be targeted via Juju
   [constraints][juju-constraints-controller] at controller-creation time.
@@ -78,7 +81,7 @@ documentation on [overlay bundles][juju-overlays].
 ## Modify the bundle
 
 If using the stable openstack-base bundle, the file to modify is
-`./stable/openstack-base/bundle.yaml`.
+`stable/openstack-base/bundle.yaml`.
 
 > **Tip**: Keep the master branch of the repository pristine and create a
   working branch to contain your modifications.
@@ -87,7 +90,7 @@ A `variables:` section is used for conveniently setting values in one place.
 The third column contains the actual values.
 
     variables:
-      openstack-origin:    &openstack-origin     cloud:focal-xena
+      openstack-origin:    &openstack-origin     cloud:focal-yoga
       data-port:           &data-port            br-ex:eno2
       worker-multiplier:   &worker-multiplier    0.25
       osd-devices:         &osd-devices          /dev/sdb /dev/vdb
@@ -166,7 +169,7 @@ See to the [Vault charm README][vault-charm-post-deploy] for instructions.
 You'll need the OpenStack clients in order to manage your cloud from the
 command line. Install them now:
 
-    sudo snap install openstackclients --classic
+    sudo snap install openstackclients
 
 ## Access the cloud
 
@@ -327,9 +330,9 @@ The final credentials needed to log in are:
 
 <!-- There are two spaces at the end of the next two lines -->
 
-User Name: **admin**  
-Password: ********************  
-Domain: **admin_domain**
+User Name: `admin`  
+Password: `***************`  
+Domain: `admin_domain`
 
 ### VM consoles
 
@@ -342,6 +345,7 @@ connect to VM consoles from within the dashboard:
 
 The below resources are recommended for further reading:
 
+* [What is OpenStack?]: for an overview of the OpenStack project
 * [OpenStack Administrator Guides][openstack-admin-guides]: for upstream
   OpenStack administrative help
 * [OpenStack Charms Deployment Guide][cdg]: for charm usage information
@@ -352,8 +356,8 @@ The below resources are recommended for further reading:
 [OpenStack Neutron]: http://docs.openstack.org/admin-guide-cloud/content/ch_networking.html
 [OpenStack Admin Guide]: http://docs.openstack.org/user-guide-admin/content
 [Ubuntu Cloud Images]: http://cloud-images.ubuntu.com/focal/current/
-[cdg]: https://docs.openstack.org/project-deploy-guide/charm-deployment-guide/xena/
-[cdg-install-openstack]: https://docs.openstack.org/project-deploy-guide/charm-deployment-guide/xena/install-openstack.html
+[cdg]: https://docs.openstack.org/project-deploy-guide/charm-deployment-guide/yoga/
+[cdg-install-openstack]: https://docs.openstack.org/project-deploy-guide/charm-deployment-guide/yoga/install-openstack.html
 [openstack-bundles]: https://github.com/openstack-charmers/openstack-bundles
 [juju-overlays]: https://jaas.ai/docs/charm-bundles#heading--overlay-bundles
 [juju-spaces]: https://jaas.ai/docs/spaces

--- a/stable/openstack-base/bundle.yaml
+++ b/stable/openstack-base/bundle.yaml
@@ -343,7 +343,7 @@ applications:
       gui-x: '300'
       gui-y: '1550'
     charm: ch:rabbitmq-server
-    channel: 3.8/stable
+    channel: 3.9/stable
     num_units: 1
     to:
     - lxd:2

--- a/stable/openstack-base/bundle.yaml
+++ b/stable/openstack-base/bundle.yaml
@@ -6,12 +6,11 @@
 #       Refer to the [Open Virtual Network (OVN)](https://docs.openstack.org/project-deploy-guide/charm-deployment-guide/latest/app-ovn.html)
 #       section of the [OpenStack Charms Deployment Guide](https://docs.openstack.org/project-deploy-guide/charm-deployment-guide/latest/)
 #       for more information.
-
+name: openstack-base
 series: focal
 variables:
-  openstack-origin: &openstack-origin cloud:focal-xena
+  openstack-origin: &openstack-origin cloud:focal-yoga
   data-port: &data-port to-be-set
-  worker-multiplier: &worker-multiplier 0.25
   osd-devices: &osd-devices /dev/sdb /dev/vdb
   expected-osd-count: &expected-osd-count 3
   expected-mon-count: &expected-mon-count 3
@@ -143,7 +142,8 @@ applications:
     annotations:
       gui-x: '790'
       gui-y: '1540'
-    charm: cs:ceph-mon-61
+    charm: ch:ceph-mon
+    channel: quincy/stable
     num_units: 3
     options:
       expected-osd-count: *expected-osd-count
@@ -157,7 +157,8 @@ applications:
     annotations:
       gui-x: '1065'
       gui-y: '1540'
-    charm: cs:ceph-osd-315
+    charm: ch:ceph-osd
+    channel: quincy/stable
     num_units: 3
     options:
       osd-devices: *osd-devices
@@ -170,7 +171,8 @@ applications:
     annotations:
       gui-x: '850'
       gui-y: '900'
-    charm: cs:ceph-radosgw-300
+    charm: ch:ceph-radosgw
+    channel: quincy/stable
     num_units: 1
     options:
       source: *openstack-origin
@@ -180,17 +182,18 @@ applications:
     annotations:
       gui-x: '900'
       gui-y: '1400'
-    charm: cs:mysql-router-15
+    charm: ch:mysql-router
+    channel: 8.0/stable
   cinder:
     annotations:
       gui-x: '980'
       gui-y: '1270'
-    charm: cs:cinder-317
+    charm: ch:cinder
+    channel: yoga/stable
     num_units: 1
     options:
       block-device: None
       glance-api-version: 2
-      worker-multiplier: *worker-multiplier
       openstack-origin: *openstack-origin
     to:
     - lxd:1
@@ -198,21 +201,23 @@ applications:
     annotations:
       gui-x: '1120'
       gui-y: '1400'
-    charm: cs:cinder-ceph-268
+    charm: ch:cinder-ceph
+    channel: yoga/stable
     num_units: 0
   glance-mysql-router:
     annotations:
       gui-x: '-290'
       gui-y: '1400'
-    charm: cs:mysql-router-15
+    charm: ch:mysql-router
+    channel: 8.0/stable
   glance:
     annotations:
       gui-x: '-230'
       gui-y: '1270'
-    charm: cs:glance-312
+    charm: ch:glance
+    channel: yoga/stable
     num_units: 1
     options:
-      worker-multiplier: *worker-multiplier
       openstack-origin: *openstack-origin
     to:
     - lxd:2
@@ -220,15 +225,16 @@ applications:
     annotations:
       gui-x: '230'
       gui-y: '1400'
-    charm: cs:mysql-router-15
+    charm: ch:mysql-router
+    channel: 8.0/stable
   keystone:
     annotations:
       gui-x: '300'
       gui-y: '1270'
-    charm: cs:keystone-329
+    charm: ch:keystone
+    channel: yoga/stable
     num_units: 1
     options:
-      worker-multiplier: *worker-multiplier
       openstack-origin: *openstack-origin
     to:
     - lxd:0
@@ -236,22 +242,24 @@ applications:
     annotations:
       gui-x: '505'
       gui-y: '1385'
-    charm: cs:mysql-router-15
+    charm: ch:mysql-router
+    channel: 8.0/stable
   neutron-api-plugin-ovn:
     annotations:
       gui-x: '690'
       gui-y: '1385'
-    charm: cs:neutron-api-plugin-ovn-10
+    charm: ch:neutron-api-plugin-ovn
+    channel: yoga/stable
   neutron-api:
     annotations:
       gui-x: '580'
       gui-y: '1270'
-    charm: cs:neutron-api-302
+    charm: ch:neutron-api
+    channel: yoga/stable
     num_units: 1
     options:
       neutron-security-groups: true
       flat-network-providers: physnet1
-      worker-multiplier: *worker-multiplier
       openstack-origin: *openstack-origin
     to:
     - lxd:1
@@ -259,15 +267,16 @@ applications:
     annotations:
       gui-x: '1320'
       gui-y: '1385'
-    charm: cs:mysql-router-15
+    charm: ch:mysql-router
+    channel: 8.0/stable
   placement:
     annotations:
       gui-x: '1320'
       gui-y: '1270'
-    charm: cs:placement-31
+    charm: ch:placement
+    channel: yoga/stable
     num_units: 1
     options:
-      worker-multiplier: *worker-multiplier
       openstack-origin: *openstack-origin
     to:
     - lxd:2
@@ -275,16 +284,17 @@ applications:
     annotations:
       gui-x: '-30'
       gui-y: '1385'
-    charm: cs:mysql-router-15
+    charm: ch:mysql-router
+    channel: 8.0/stable
   nova-cloud-controller:
     annotations:
       gui-x: '35'
       gui-y: '1270'
-    charm: cs:nova-cloud-controller-361
+    charm: ch:nova-cloud-controller
+    channel: yoga/stable
     num_units: 1
     options:
       network-manager: Neutron
-      worker-multiplier: *worker-multiplier
       openstack-origin: *openstack-origin
     to:
     - lxd:0
@@ -292,7 +302,8 @@ applications:
     annotations:
       gui-x: '190'
       gui-y: '890'
-    charm: cs:nova-compute-337
+    charm: ch:nova-compute
+    channel: yoga/stable
     num_units: 3
     options:
       config-flags: default_ephemeral_format=ext4
@@ -314,12 +325,14 @@ applications:
     annotations:
       gui-x: '510'
       gui-y: '1030'
-    charm: cs:mysql-router-15
+    charm: ch:mysql-router
+    channel: 8.0/stable
   openstack-dashboard:
     annotations:
       gui-x: '585'
       gui-y: '900'
-    charm: cs:openstack-dashboard-318
+    charm: ch:openstack-dashboard
+    channel: yoga/stable
     num_units: 1
     options:
       openstack-origin: *openstack-origin
@@ -329,7 +342,8 @@ applications:
     annotations:
       gui-x: '300'
       gui-y: '1550'
-    charm: cs:rabbitmq-server-117
+    charm: ch:rabbitmq-server
+    channel: 3.8/stable
     num_units: 1
     to:
     - lxd:2
@@ -337,7 +351,8 @@ applications:
     annotations:
       gui-x: '535'
       gui-y: '1550'
-    charm: cs:mysql-innodb-cluster-15
+    charm: ch:mysql-innodb-cluster
+    channel: 8.0/stable
     num_units: 3
     to:
     - lxd:0
@@ -347,7 +362,8 @@ applications:
     annotations:
       gui-x: '70'
       gui-y: '1550'
-    charm: cs:ovn-central-15
+    charm: ch:ovn-central
+    channel: 22.03/stable
     num_units: 3
     options:
       source: *openstack-origin
@@ -359,7 +375,8 @@ applications:
     annotations:
       gui-x: '120'
       gui-y: '1030'
-    charm: cs:ovn-chassis-21
+    charm: ch:ovn-chassis
+    channel: 22.03/stable
     # Please update the `bridge-interface-mappings` to values suitable for the
     # hardware used in your deployment. See the referenced documentation at the
     # top of this file.
@@ -370,12 +387,14 @@ applications:
     annotations:
       gui-x: '1535'
       gui-y: '1560'
-    charm: cs:mysql-router-15
+    charm: ch:mysql-router
+    channel: 8.0/stable
   vault:
     annotations:
       gui-x: '1610'
       gui-y: '1430'
-    charm: cs:vault-54
+    charm: ch:vault
+    channel: 1.7/stable
     num_units: 1
     to:
     - lxd:0

--- a/stable/openstack-base/charmcraft.yaml
+++ b/stable/openstack-base/charmcraft.yaml
@@ -1,0 +1,17 @@
+type: bundle
+
+parts:
+  bundle:
+    prime:
+      - bundle.yaml
+      - openrc
+      - openrcv3_domain
+      - openrcv3_project
+      - openstack-base-spaces-overlay.yaml
+      - README.md
+      - repo-info
+      - test-requirements.txt
+      - tests/bundles/bundle.yaml
+      - tests/bundles/overlays/bundle.yaml.j2
+      - tests/tests.yaml
+      - tox.ini

--- a/stable/openstack-telemetry/bundle.yaml
+++ b/stable/openstack-telemetry/bundle.yaml
@@ -10,7 +10,7 @@
 local_overlay_enabled: true
 series: focal
 variables:
-  openstack-origin: &openstack-origin cloud:focal-xena
+  openstack-origin: &openstack-origin cloud:focal-yoga
   data-port: &data-port to-be-set
   worker-multiplier: &worker-multiplier 0.25
   osd-devices: &osd-devices /dev/sdb /dev/vdb
@@ -183,35 +183,39 @@ applications:
     annotations:
       gui-x: '1500'
       gui-y: '0'
-    charm: cs:aodh-56
+    charm: ch:aodh
     num_units: 1
     options:
       openstack-origin: *openstack-origin
     to:
     - lxd:0
+    channel: yoga/edge
   aodh-mysql-router:
-    charm: cs:mysql-router-15
+    charm: ch:mysql-router
+    channel: 8.0/edge
   ceilometer:
     annotations:
       gui-x: '1250'
       gui-y: '0'
-    charm: cs:ceilometer-288
+    charm: ch:ceilometer
     num_units: 1
     options:
       openstack-origin: *openstack-origin
     to:
     - lxd:2
+    channel: yoga/edge
   ceilometer-agent:
     annotations:
       gui-x: '1250'
       gui-y: '500'
-    charm: cs:ceilometer-agent-277
+    charm: ch:ceilometer-agent
+    channel: yoga/edge
     num_units: 0
   ceph-mon:
     annotations:
       gui-x: '790'
       gui-y: '1540'
-    charm: cs:ceph-mon-61
+    charm: ch:ceph-mon
     num_units: 3
     options:
       expected-osd-count: *expected-osd-count
@@ -221,11 +225,12 @@ applications:
     - lxd:0
     - lxd:1
     - lxd:2
+    channel: quincy/edge
   ceph-osd:
     annotations:
       gui-x: '1065'
       gui-y: '1540'
-    charm: cs:ceph-osd-315
+    charm: ch:ceph-osd
     num_units: 3
     options:
       osd-devices: *osd-devices
@@ -234,26 +239,29 @@ applications:
     - '0'
     - '1'
     - '2'
+    channel: quincy/edge
   ceph-radosgw:
     annotations:
       gui-x: '850'
       gui-y: '900'
-    charm: cs:ceph-radosgw-300
+    charm: ch:ceph-radosgw
     num_units: 1
     options:
       source: *openstack-origin
     to:
     - lxd:0
+    channel: quincy/edge
   cinder-mysql-router:
     annotations:
       gui-x: '900'
       gui-y: '1400'
-    charm: cs:mysql-router-15
+    charm: ch:mysql-router
+    channel: 8.0/edge
   cinder:
     annotations:
       gui-x: '980'
       gui-y: '1270'
-    charm: cs:cinder-317
+    charm: ch:cinder
     num_units: 1
     options:
       block-device: None
@@ -262,59 +270,67 @@ applications:
       openstack-origin: *openstack-origin
     to:
     - lxd:1
+    channel: yoga/edge
   cinder-ceph:
     annotations:
       gui-x: '1120'
       gui-y: '1400'
-    charm: cs:cinder-ceph-268
+    charm: ch:cinder-ceph
     num_units: 0
+    channel: yoga/edge
   glance-mysql-router:
     annotations:
       gui-x: '-290'
       gui-y: '1400'
-    charm: cs:mysql-router-15
+    charm: ch:mysql-router
+    channel: 8.0/edge
   glance:
     annotations:
       gui-x: '-230'
       gui-y: '1270'
-    charm: cs:glance-312
+    charm: ch:glance
     num_units: 1
     options:
       worker-multiplier: *worker-multiplier
       openstack-origin: *openstack-origin
     to:
     - lxd:2
+    channel: yoga/edge
   keystone-mysql-router:
     annotations:
       gui-x: '230'
       gui-y: '1400'
-    charm: cs:mysql-router-15
+    charm: ch:mysql-router
+    channel: 8.0/edge
   keystone:
     annotations:
       gui-x: '300'
       gui-y: '1270'
-    charm: cs:keystone-329
+    charm: ch:keystone
     num_units: 1
     options:
       worker-multiplier: *worker-multiplier
       openstack-origin: *openstack-origin
     to:
     - lxd:0
+    channel: yoga/edge
   neutron-mysql-router:
     annotations:
       gui-x: '505'
       gui-y: '1385'
-    charm: cs:mysql-router-15
+    charm: ch:mysql-router
+    channel: 8.0/edge
   neutron-api-plugin-ovn:
     annotations:
       gui-x: '690'
       gui-y: '1385'
-    charm: cs:neutron-api-plugin-ovn-10
+    charm: ch:neutron-api-plugin-ovn
+    channel: yoga/edge
   neutron-api:
     annotations:
       gui-x: '580'
       gui-y: '1270'
-    charm: cs:neutron-api-302
+    charm: ch:neutron-api
     num_units: 1
     options:
       neutron-security-groups: true
@@ -323,32 +339,36 @@ applications:
       openstack-origin: *openstack-origin
     to:
     - lxd:1
+    channel: yoga/edge
   placement-mysql-router:
     annotations:
       gui-x: '1320'
       gui-y: '1385'
-    charm: cs:mysql-router-15
+    charm: ch:mysql-router
+    channel: 8.0/edge
   placement:
     annotations:
       gui-x: '1320'
       gui-y: '1270'
-    charm: cs:placement-31
+    charm: ch:placement
     num_units: 1
     options:
       worker-multiplier: *worker-multiplier
       openstack-origin: *openstack-origin
     to:
     - lxd:2
+    channel: yoga/edge
   nova-mysql-router:
     annotations:
       gui-x: '-30'
       gui-y: '1385'
-    charm: cs:mysql-router-15
+    charm: ch:mysql-router
+    channel: 8.0/edge
   nova-cloud-controller:
     annotations:
       gui-x: '35'
       gui-y: '1270'
-    charm: cs:nova-cloud-controller-361
+    charm: ch:nova-cloud-controller
     num_units: 1
     options:
       network-manager: Neutron
@@ -356,11 +376,12 @@ applications:
       openstack-origin: *openstack-origin
     to:
     - lxd:0
+    channel: yoga/edge
   nova-compute:
     annotations:
       gui-x: '190'
       gui-y: '890'
-    charm: cs:nova-compute-337
+    charm: ch:nova-compute
     num_units: 3
     options:
       config-flags: default_ephemeral_format=ext4
@@ -372,50 +393,55 @@ applications:
     - '0'
     - '1'
     - '2'
+    channel: yoga/edge
   ntp:
     annotations:
       gui-x: '315'
       gui-y: '1030'
-    charm: cs:ntp-47
+    charm: ch:ntp
     num_units: 0
   dashboard-mysql-router:
     annotations:
       gui-x: '510'
       gui-y: '1030'
-    charm: cs:mysql-router-15
+    charm: ch:mysql-router
+    channel: 8.0/edge
   openstack-dashboard:
     annotations:
       gui-x: '585'
       gui-y: '900'
-    charm: cs:openstack-dashboard-318
+    charm: ch:openstack-dashboard
     num_units: 1
     options:
       openstack-origin: *openstack-origin
     to:
     - lxd:1
+    channel: yoga/edge
   rabbitmq-server:
     annotations:
       gui-x: '300'
       gui-y: '1550'
-    charm: cs:rabbitmq-server-117
+    charm: ch:rabbitmq-server
     num_units: 1
     to:
     - lxd:2
+    channel: 3.9/edge
   mysql-innodb-cluster:
     annotations:
       gui-x: '535'
       gui-y: '1550'
-    charm: cs:mysql-innodb-cluster-15
+    charm: ch:mysql-innodb-cluster
     num_units: 3
     to:
     - lxd:0
     - lxd:1
     - lxd:2
+    channel: 8.0/edge
   ovn-central:
     annotations:
       gui-x: '70'
       gui-y: '1550'
-    charm: cs:ovn-central-15
+    charm: ch:ovn-central
     num_units: 3
     options:
       source: *openstack-origin
@@ -423,27 +449,31 @@ applications:
     - lxd:0
     - lxd:1
     - lxd:2
+    channel: 22.03/edge
   ovn-chassis:
     annotations:
       gui-x: '120'
       gui-y: '1030'
-    charm: cs:ovn-chassis-21
+    charm: ch:ovn-chassis
     # Please update the `bridge-interface-mappings` to values suitable for the
     # hardware used in your deployment. See the referenced documentation at the
     # top of this file.
     options:
       ovn-bridge-mappings: physnet1:br-ex
       bridge-interface-mappings: *data-port
+    channel: 22.03/edge
   vault-mysql-router:
     annotations:
       gui-x: '1535'
       gui-y: '1560'
-    charm: cs:mysql-router-15
+    charm: ch:mysql-router
+    channel: 8.0/edge
   vault:
     annotations:
       gui-x: '1610'
       gui-y: '1430'
-    charm: cs:vault-54
+    charm: ch:vault
+    channel: 1.7/edge
     num_units: 1
     to:
     - lxd:0
@@ -452,19 +482,21 @@ applications:
       gui-x: '1500'
       gui-y: '250'
     num_units: 1
-    charm: cs:gnocchi-51
+    charm: ch:gnocchi
     options:
       openstack-origin: *openstack-origin
     to:
     - lxd:1
+    channel: yoga/edge
   gnocchi-mysql-router:
-    charm: cs:mysql-router-15
+    charm: ch:mysql-router
+    channel: 8.0/edge
   memcached:
     series: bionic
     annotations:
       gui-x: '1500'
       gui-y: '500'
     num_units: 1
-    charm: cs:memcached-34
+    charm: ch:memcached
     to:
     - lxd:2

--- a/stable/openstack-telemetry/charmcraft.yaml
+++ b/stable/openstack-telemetry/charmcraft.yaml
@@ -1,0 +1,12 @@
+type: bundle
+
+parts:
+  bundle:
+    prime:
+      - bundle.yaml
+      - openrc
+      - openrcv3_domain
+      - openrcv3_project
+      - openstack-telemetry-spaces-overlay.yaml
+      - README.md
+      - repo-info


### PR DESCRIPTION
Update the openstack-bundles repository to use charmcraft for bundle publishing and update the stable bundles to release focal-yoga and focal-quincy.