### PR TITLE
Add zed bundles in the development section

### DIFF
--- a/.github/workflows/tox.yaml
+++ b/.github/workflows/tox.yaml
@@ -39,6 +39,6 @@ jobs:
         sudo chmod 666 /var/snap/lxd/common/lxd/unix.socket
         # until Juju provides stable IPv6-support we unfortunately need this
         lxc network set lxdbr0 ipv6.address none
-        juju bootstrap --no-gui localhost
+        juju bootstrap --debug --show-log --no-gui localhost
     - name: Bundle validation with tox using dry-run juju deploy
       run: tox -e lint

--- a/development/openstack-base-jammy-zed/README.md
+++ b/development/openstack-base-jammy-zed/README.md
@@ -1,0 +1,369 @@
+# Basic OpenStack cloud
+
+**TESTING ONLY - This is a development bundle.** See the `stable` directory for
+the stable bundles.
+
+This `openstack-base` bundle deploys a base OpenStack cloud. Its major elements
+include:
+
+* Ubuntu 22.04 LTS (Jammy)
+* OpenStack Zed
+* Ceph Quincy
+
+Cloud services consist of Compute, Network, Block Storage, Object Storage,
+Identity, Image, and Dashboard.
+
+> **Note**: Modifications will typically need to be made to this bundle for it
+  to work in your environment.
+
+## Requirements
+
+The bundle is primarily designed to work with [MAAS][maas] as a backing cloud
+for Juju.
+
+The MAAS cluster must have a minimum of four nodes:
+
+* one for the Juju controller, with at least 1 CPU and 4 GiB memory
+
+* three (ideally identical) for the actual cloud, with minimum resources
+  being:
+
+    * 8 GiB memory
+    * enough CPU cores to support your workload
+    * two disks
+    * two cabled network interfaces
+
+  The first disk is used for the node's operating system, and the second is for
+  Ceph storage.
+
+  The first network interface is used for communication between cloud services
+  (East/West traffic), and the second is for network traffic between the cloud
+  and all external networks (North/South traffic).
+
+> **Note**: The smaller controller node can be targeted via Juju
+  [constraints][juju-constraints-controller] at controller-creation time.
+
+## Topology
+
+* 3 MAAS nodes, with each hosting one of the following:
+    * Ceph storage
+    * Nova Compute
+    * NTP
+
+* LXD containers for the following (distributed among the 3 MAAS nodes):
+    * Ceph monitors (x3)
+    * Ceph RADOS Gateway
+    * Cinder
+    * Glance
+    * Horizon
+    * Keystone
+    * MySQL8 (x3)
+    * Neutron
+    * Nova Cloud Controller
+    * OVN (x3)
+    * Placement
+    * RabbitMQ
+    * Vault
+
+## Download the bundle
+
+If not already done, clone the [openstack-bundles][openstack-bundles]
+repository:
+
+    git clone https://github.com/openstack-charmers/openstack-bundles
+
+The stable and development bundles are found under the `stable/openstack-base`
+and `development` directories respectively.
+
+Overlay bundles are available under `stable/overlays`. See the Juju
+documentation on [overlay bundles][juju-overlays].
+
+## Modify the bundle
+
+If using the stable openstack-base bundle, the file to modify is
+`./stable/openstack-base/bundle.yaml`.
+
+> **Tip**: Keep the master branch of the repository pristine and create a
+  working branch to contain your modifications.
+
+A `variables:` section is used for conveniently setting values in one place.
+The third column contains the actual values.
+
+    variables:
+      openstack-origin:    &openstack-origin     distro
+      data-port:           &data-port            br-ex:eno2
+      worker-multiplier:   &worker-multiplier    0.25
+      osd-devices:         &osd-devices          /dev/sdb /dev/vdb
+      expected-osd-count:  &expected-osd-count   3
+      expected-mon-count:  &expected-mon-count   3
+
+See the [Install OpenStack][cdg-install-openstack] page in the [OpenStack
+Charms Deployment Guide][cdg] for help on understanding the variables (the
+first column).
+
+### Network spaces
+
+If you're using MAAS and it contains network spaces you will need to bind them
+to the applications being deployed. One way of doing this is with the
+`openstack-base-spaces-overlay.yaml` overlay bundle. Like the main bundle file,
+it will likely require tailoring:
+
+    variables:
+      public-space:        &public-space         public-space
+
+See the Juju documentation on [network spaces][juju-spaces].
+
+### Containerless
+
+If you do not want to run containers you will need to undo the placement
+directives that point to containers. One way of doing this is with the
+`openstack-base-virt-overlay.yaml` overlay bundle.
+
+## MAAS cloud, Juju controller, and model
+
+Ensure that the MAAS cluster has been added to Juju as a cloud and that a Juju
+controller has been created for that cloud. See the Juju documentation for
+guidance: [Using MAAS with Juju][juju-and-maas].
+
+Assuming the controller is called 'maas-controller', create a model called,
+say, 'openstack' and give it the appropriate default series (e.g. jammy):
+
+    juju add-model -c maas-controller --config default-series=jammy openstack
+
+Now ensure that the new model is the current model:
+
+    juju switch maas-controller:openstack
+
+## Deploy the cloud
+
+To install OpenStack, if you're using the spaces overlay:
+
+    juju deploy ./bundle.yaml --overlay ./openstack-base-spaces-overlay.yaml
+
+Otherwise, simply do:
+
+    juju deploy ./bundle.yaml
+
+If you're using a custom overlay (to override elements in earlier bundles)
+simply append it to the command:
+
+    juju deploy ./bundle.yaml --overlay ./custom-overlay.yaml
+    juju deploy ./bundle.yaml --overlay ./openstack-base-spaces-overlay.yaml --overlay ./custom-overlay.yaml
+
+> **Note**: Here it is assumed, for the sake of brevity, that the YAML files
+  are in the current working directory.
+
+### Issue TLS certificates
+
+This bundle uses Vault to issue TLS certificates to services, and some
+post-deployment steps are needed in order for it to work. Failure to complete
+them, for example, will leave the OVN deployment with the following message (in
+`juju status`):
+
+    'ovsdb-*' incomplete, 'certificates' awaiting server certificate data
+
+See to the [Vault charm README][vault-charm-post-deploy] for instructions.
+
+## Install the OpenStack clients
+
+You'll need the OpenStack clients in order to manage your cloud from the
+command line. Install them now:
+
+    sudo snap install openstackclients --classic
+
+## Access the cloud
+
+Confirm that you can access the cloud from the command line:
+
+    source ~/openstack-bundles/stable/openstack-base/openrc
+    openstack service list
+
+You should get a listing of all registered cloud services.
+
+## Import an image
+
+You'll need to import an image into Glance in order to create instances.
+
+First download a boot image, like Focal amd64:
+
+    curl http://cloud-images.ubuntu.com/focal/current/focal-server-cloudimg-amd64.img \
+       --output ~/cloud-images/focal-amd64.img
+
+Now import the image and call it 'focal-amd64':
+
+    openstack image create --public --container-format bare \
+       --disk-format qcow2 --file ~/cloud-images/focal-amd64.img \
+       focal-amd64
+
+Images for other Ubuntu releases and architectures can be obtained in a similar
+way.
+
+For the ARM 64-bit (arm64) architecture you will need to configure the image to
+boot in UEFI mode:
+
+    curl http://cloud-images.ubuntu.com/focal/current/focal-server-cloudimg-amd64.img \
+       --output ~/cloud-images/focal-arm64.img
+
+    openstack image create --public --container-format bare \
+       --disk-format qcow2 --property hw_firmware_type=uefi \
+       --file ~/cloud-images/focal-arm64.img \
+       focal-arm64
+
+## Configure networking
+
+For the purposes of a quick test, we'll set up an external network and a
+shared router ('provider-router') that will be used by all tenants for public
+access to instances.
+
+For an example private cloud, create a network ('ext_net'):
+
+    openstack network create --external \
+       --provider-network-type flat --provider-physical-network physnet1 \
+       ext_net
+
+When creating the external subnet ('ext_subnet') the actual values used will
+depend on the environment that the second network interface (on all nodes) is
+connected to:
+
+    openstack subnet create --network ext_net --no-dhcp \
+       --gateway 10.0.0.1 --subnet-range 10.0.0.0/21 \
+       --allocation-pool start=10.0.0.10,end=10.0.0.200 \
+       ext_subnet
+
+> **Note**: For a public cloud the ports would be connected to a publicly
+  addressable part of the internet.
+
+We'll also need an internal network ('int_net'), subnet ('int_subnet'), and
+router ('provider-router'):
+
+    openstack network create int_net
+
+    openstack subnet create --network int_net --dns-nameserver 8.8.8.8 \
+       --gateway 192.168.0.1 --subnet-range 192.168.0.0/24 \
+       --allocation-pool start=192.168.0.10,end=192.168.0.200 \
+       int_subnet
+
+    openstack router create provider-router
+    openstack router set --external-gateway ext_net provider-router
+    openstack router add subnet provider-router int_subnet
+
+See the [Neutron documentation][openstack-neutron] for more information.
+
+## Create a flavor
+
+Create at least one flavor to define a hardware profile for new instances. Here
+we create one called 'm1.small':
+
+    openstack flavor create --ram 2048 --disk 20 --ephemeral 20 m1.small
+
+Make sure that your MAAS nodes can accommodate the flavor's resources.
+
+## Import an SSH keypair
+
+An SSH keypair needs to be imported into the cloud in order to access your
+instances.
+
+Generate one first if you do not yet have one. This command creates a
+passphraseless keypair (remove the `-N` option to avoid that):
+
+    ssh-keygen -q -N '' -f ~/cloud-keys/id_mykey
+
+To import a keypair:
+
+    openstack keypair create --public-key ~/cloud-keys/id_mykey.pub mykey
+
+## Configure security groups
+
+To allow ICMP (ping) and SSH traffic to flow to cloud instances create
+corresponding rules for each existing security group:
+
+    for i in $(openstack security group list | awk '/default/{ print $2 }'); do
+       openstack security group rule create $i --protocol icmp --remote-ip 0.0.0.0/0;
+       openstack security group rule create $i --protocol tcp --remote-ip 0.0.0.0/0 --dst-port 22;
+    done
+
+You only need to perform this step once.
+
+## Create an instance
+
+Create a Focal amd64 instance called 'focal-1':
+
+    openstack server create --image focal-amd64 --flavor m1.small \
+       --key-name mykey --network int_net \
+        focal-1
+
+## Assign a floating IP address
+
+Request and assign a floating IP address to the new instance:
+
+    FLOATING_IP=$(openstack floating ip create -f value -c floating_ip_address ext_net)
+    openstack server add floating ip focal-1 $FLOATING_IP
+
+## Log in to an instance
+
+Log in to the new instance:
+
+    ssh -i ~/cloud-keys/id_mykey ubuntu@$FLOATING_IP
+
+The below commands are a good start to troubleshooting if something goes wrong:
+
+    openstack console log show focal-1
+    openstack server show focal-1
+
+## Access the cloud dashboard
+
+To access the dashboard (Horizon) first obtain its IP address:
+
+    juju status --format=yaml openstack-dashboard | grep public-address | awk '{print $2}' | head -1
+
+In this example, the address is '10.0.0.30'.
+
+The password can be queried from Keystone:
+
+    juju run --unit keystone/leader leader-get admin_passwd
+
+The dashboard URL then becomes:
+
+**http://10.0.0.30/horizon**
+
+The final credentials needed to log in are:
+
+<!-- There are two spaces at the end of the next two lines -->
+
+User Name: **admin**  
+Password: ********************  
+Domain: **admin_domain**
+
+### VM consoles
+
+Enable a remote access protocol such as `novnc` (or `spice`) if you want to
+connect to VM consoles from within the dashboard:
+
+    juju config nova-cloud-controller console-access-protocol=novnc
+
+## Further reading
+
+The below resources are recommended for further reading:
+
+* [What is OpenStack?]: for an overview of the OpenStack project
+* [OpenStack Administrator Guides][openstack-admin-guides]: for upstream
+  OpenStack administrative help
+* [OpenStack Charms Deployment Guide][cdg]: for charm usage information
+
+<!-- LINKS -->
+
+[maas]: http://maas.io/docs
+[OpenStack Neutron]: http://docs.openstack.org/admin-guide-cloud/content/ch_networking.html
+[OpenStack Admin Guide]: http://docs.openstack.org/user-guide-admin/content
+[Ubuntu Cloud Images]: http://cloud-images.ubuntu.com/focal/current/
+[cdg]: https://docs.openstack.org/project-deploy-guide/charm-deployment-guide/yoga/
+[cdg-install-openstack]: https://docs.openstack.org/project-deploy-guide/charm-deployment-guide/yoga/install-openstack.html
+[openstack-bundles]: https://github.com/openstack-charmers/openstack-bundles
+[juju-overlays]: https://jaas.ai/docs/charm-bundles#heading--overlay-bundles
+[juju-spaces]: https://jaas.ai/docs/spaces
+[juju-constraints-controller]: https://jaas.ai/docs/constraints#heading--setting-constraints-for-a-controller
+[juju-and-maas]: https://jaas.ai/docs/maas-cloud
+[vault-charm-post-deploy]: https://opendev.org/openstack/charm-vault/src/branch/master/src/README.md#post-deployment-tasks
+[openstack-neutron]: https://docs.openstack.org/neutron/
+[openstack-admin-guides]: http://docs.openstack.org/admin
+[What is OpenStack?]: https://ubuntu.com/openstack/what-is-openstack

--- a/development/openstack-base-jammy-zed/bundle.yaml
+++ b/development/openstack-base-jammy-zed/bundle.yaml
@@ -1,0 +1,406 @@
+local_overlay_enabled: False
+
+# Please refer to the OpenStack Charms Deployment Guide for more information.
+# https://docs.openstack.org/project-deploy-guide/charm-deployment-guide
+#
+# NOTE: Please review the value for the configuration option
+#       `bridge-interface-mappings` for the `ovn-chassis` charm (see `data-port` variable).
+#       Refer to the [Open Virtual Network (OVN)](https://docs.openstack.org/project-deploy-guide/charm-deployment-guide/latest/app-ovn.html)
+#       section of the [OpenStack Charms Deployment Guide](https://docs.openstack.org/project-deploy-guide/charm-deployment-guide/latest/)
+#       for more information.
+name: openstack-base
+series: jammy
+variables:
+  openstack-origin: &openstack-origin cloud:jammy-zed
+  openstack-charm-channel: &openstack-charm-channel zed/edge
+  ovn-charm-channel: &ovn-charm-channel 22.09/edge
+  ceph-charm-channel: &ceph-charm-channel quincy/edge
+  mysql-charm-channel: &mysql-charm-channel 8.0/edge
+  data-port: &data-port to-be-set
+  osd-devices: &osd-devices /dev/sdb /dev/vdb
+  expected-osd-count: &expected-osd-count 3
+  expected-mon-count: &expected-mon-count 3
+machines:
+  '0':
+  '1':
+  '2':
+relations:
+- - nova-compute:amqp
+  - rabbitmq-server:amqp
+- - nova-cloud-controller:identity-service
+  - keystone:identity-service
+- - glance:identity-service
+  - keystone:identity-service
+- - neutron-api:identity-service
+  - keystone:identity-service
+- - neutron-api:amqp
+  - rabbitmq-server:amqp
+- - glance:amqp
+  - rabbitmq-server:amqp
+- - nova-cloud-controller:image-service
+  - glance:image-service
+- - nova-compute:image-service
+  - glance:image-service
+- - nova-cloud-controller:cloud-compute
+  - nova-compute:cloud-compute
+- - nova-cloud-controller:amqp
+  - rabbitmq-server:amqp
+- - openstack-dashboard:identity-service
+  - keystone:identity-service
+- - nova-cloud-controller:neutron-api
+  - neutron-api:neutron-api
+- - cinder:image-service
+  - glance:image-service
+- - cinder:amqp
+  - rabbitmq-server:amqp
+- - cinder:identity-service
+  - keystone:identity-service
+- - cinder:cinder-volume-service
+  - nova-cloud-controller:cinder-volume-service
+- - cinder-ceph:storage-backend
+  - cinder:storage-backend
+- - ceph-mon:client
+  - nova-compute:ceph
+- - nova-compute:ceph-access
+  - cinder-ceph:ceph-access
+- - ceph-mon:client
+  - cinder-ceph:ceph
+- - ceph-mon:client
+  - glance:ceph
+- - ceph-osd:mon
+  - ceph-mon:osd
+- - ntp:juju-info
+  - nova-compute:juju-info
+- - ceph-radosgw:mon
+  - ceph-mon:radosgw
+- - ceph-radosgw:identity-service
+  - keystone:identity-service
+- - placement:identity-service
+  - keystone:identity-service
+- - placement:placement
+  - nova-cloud-controller:placement
+- - keystone:shared-db
+  - keystone-mysql-router:shared-db
+- - cinder:shared-db
+  - cinder-mysql-router:shared-db
+- - glance:shared-db
+  - glance-mysql-router:shared-db
+- - nova-cloud-controller:shared-db
+  - nova-mysql-router:shared-db
+- - neutron-api:shared-db
+  - neutron-mysql-router:shared-db
+- - openstack-dashboard:shared-db
+  - dashboard-mysql-router:shared-db
+- - placement:shared-db
+  - placement-mysql-router:shared-db
+- - vault:shared-db
+  - vault-mysql-router:shared-db
+- - keystone-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - cinder-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - nova-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - glance-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - neutron-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - dashboard-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - placement-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - vault-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - neutron-api-plugin-ovn:neutron-plugin
+  - neutron-api:neutron-plugin-api-subordinate
+- - ovn-central:certificates
+  - vault:certificates
+- - ovn-central:ovsdb-cms
+  - neutron-api-plugin-ovn:ovsdb-cms
+- - neutron-api:certificates
+  - vault:certificates
+- - ovn-chassis:nova-compute
+  - nova-compute:neutron-plugin
+- - ovn-chassis:certificates
+  - vault:certificates
+- - ovn-chassis:ovsdb
+  - ovn-central:ovsdb
+- - vault:certificates
+  - neutron-api-plugin-ovn:certificates
+- - vault:certificates
+  - cinder:certificates
+- - vault:certificates
+  - glance:certificates
+- - vault:certificates
+  - keystone:certificates
+- - vault:certificates
+  - nova-cloud-controller:certificates
+- - vault:certificates
+  - openstack-dashboard:certificates
+- - vault:certificates
+  - placement:certificates
+- - vault:certificates
+  - ceph-radosgw:certificates
+- - vault:certificates
+  - mysql-innodb-cluster:certificates
+applications:
+  ceph-mon:
+    annotations:
+      gui-x: '790'
+      gui-y: '1540'
+    charm: ch:ceph-mon
+    channel: *ceph-charm-channel
+    num_units: 3
+    options:
+      expected-osd-count: *expected-osd-count
+      monitor-count: *expected-mon-count
+      source: *openstack-origin
+    to:
+    - lxd:0
+    - lxd:1
+    - lxd:2
+  ceph-osd:
+    annotations:
+      gui-x: '1065'
+      gui-y: '1540'
+    charm: ch:ceph-osd
+    channel: *ceph-charm-channel
+    num_units: 3
+    options:
+      osd-devices: *osd-devices
+      source: *openstack-origin
+    to:
+    - '0'
+    - '1'
+    - '2'
+  ceph-radosgw:
+    annotations:
+      gui-x: '850'
+      gui-y: '900'
+    charm: ch:ceph-radosgw
+    channel: *ceph-charm-channel
+    num_units: 1
+    options:
+      source: *openstack-origin
+    to:
+    - lxd:0
+  cinder-mysql-router:
+    annotations:
+      gui-x: '900'
+      gui-y: '1400'
+    charm: ch:mysql-router
+    channel: *mysql-charm-channel
+  cinder:
+    annotations:
+      gui-x: '980'
+      gui-y: '1270'
+    charm: ch:cinder
+    channel: *openstack-charm-channel
+    num_units: 1
+    options:
+      block-device: None
+      glance-api-version: 2
+      openstack-origin: *openstack-origin
+    to:
+    - lxd:1
+  cinder-ceph:
+    annotations:
+      gui-x: '1120'
+      gui-y: '1400'
+    charm: ch:cinder-ceph
+    channel: *openstack-charm-channel
+    num_units: 0
+  glance-mysql-router:
+    annotations:
+      gui-x: '-290'
+      gui-y: '1400'
+    charm: ch:mysql-router
+    channel: *mysql-charm-channel
+  glance:
+    annotations:
+      gui-x: '-230'
+      gui-y: '1270'
+    charm: ch:glance
+    channel: *openstack-charm-channel
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+    to:
+    - lxd:2
+  keystone-mysql-router:
+    annotations:
+      gui-x: '230'
+      gui-y: '1400'
+    charm: ch:mysql-router
+    channel: *mysql-charm-channel
+  keystone:
+    annotations:
+      gui-x: '300'
+      gui-y: '1270'
+    charm: ch:keystone
+    channel: *openstack-charm-channel
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+    to:
+    - lxd:0
+  neutron-mysql-router:
+    annotations:
+      gui-x: '505'
+      gui-y: '1385'
+    charm: ch:mysql-router
+    channel: *mysql-charm-channel
+  neutron-api-plugin-ovn:
+    annotations:
+      gui-x: '690'
+      gui-y: '1385'
+    charm: ch:neutron-api-plugin-ovn
+    channel: *openstack-charm-channel
+  neutron-api:
+    annotations:
+      gui-x: '580'
+      gui-y: '1270'
+    charm: ch:neutron-api
+    channel: *openstack-charm-channel
+    num_units: 1
+    options:
+      neutron-security-groups: true
+      flat-network-providers: physnet1
+      openstack-origin: *openstack-origin
+    to:
+    - lxd:1
+  placement-mysql-router:
+    annotations:
+      gui-x: '1320'
+      gui-y: '1385'
+    charm: ch:mysql-router
+    channel: *mysql-charm-channel
+  placement:
+    annotations:
+      gui-x: '1320'
+      gui-y: '1270'
+    charm: ch:placement
+    channel: *openstack-charm-channel
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+    to:
+    - lxd:2
+  nova-mysql-router:
+    annotations:
+      gui-x: '-30'
+      gui-y: '1385'
+    charm: ch:mysql-router
+    channel: *mysql-charm-channel
+  nova-cloud-controller:
+    annotations:
+      gui-x: '35'
+      gui-y: '1270'
+    charm: ch:nova-cloud-controller
+    channel: *openstack-charm-channel
+    num_units: 1
+    options:
+      network-manager: Neutron
+      openstack-origin: *openstack-origin
+    to:
+    - lxd:0
+  nova-compute:
+    annotations:
+      gui-x: '190'
+      gui-y: '890'
+    charm: ch:nova-compute
+    channel: *openstack-charm-channel
+    num_units: 3
+    options:
+      config-flags: default_ephemeral_format=ext4
+      enable-live-migration: true
+      enable-resize: true
+      migration-auth-type: ssh
+      openstack-origin: *openstack-origin
+    to:
+    - '0'
+    - '1'
+    - '2'
+  ntp:
+    annotations:
+      gui-x: '315'
+      gui-y: '1030'
+    charm: ch:ntp
+    num_units: 0
+  dashboard-mysql-router:
+    annotations:
+      gui-x: '510'
+      gui-y: '1030'
+    charm: ch:mysql-router
+    channel: *mysql-charm-channel
+  openstack-dashboard:
+    annotations:
+      gui-x: '585'
+      gui-y: '900'
+    charm: ch:openstack-dashboard
+    channel: *openstack-charm-channel
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+    to:
+    - lxd:1
+  rabbitmq-server:
+    annotations:
+      gui-x: '300'
+      gui-y: '1550'
+    charm: ch:rabbitmq-server
+    channel: 3.9/edge
+    num_units: 1
+    to:
+    - lxd:2
+  mysql-innodb-cluster:
+    annotations:
+      gui-x: '535'
+      gui-y: '1550'
+    charm: ch:mysql-innodb-cluster
+    channel: *mysql-charm-channel
+    num_units: 3
+    to:
+    - lxd:0
+    - lxd:1
+    - lxd:2
+  ovn-central:
+    annotations:
+      gui-x: '70'
+      gui-y: '1550'
+    charm: ch:ovn-central
+    channel: *ovn-charm-channel
+    num_units: 3
+    options:
+      source: *openstack-origin
+    to:
+    - lxd:0
+    - lxd:1
+    - lxd:2
+  ovn-chassis:
+    annotations:
+      gui-x: '120'
+      gui-y: '1030'
+    charm: ch:ovn-chassis
+    channel: *ovn-charm-channel
+    # Please update the `bridge-interface-mappings` to values suitable for the
+    # hardware used in your deployment. See the referenced documentation at the
+    # top of this file.
+    options:
+      ovn-bridge-mappings: physnet1:br-ex
+      bridge-interface-mappings: *data-port
+  vault-mysql-router:
+    annotations:
+      gui-x: '1535'
+      gui-y: '1560'
+    charm: ch:mysql-router
+    channel: *mysql-charm-channel
+  vault:
+    annotations:
+      gui-x: '1610'
+      gui-y: '1430'
+    charm: ch:vault
+    channel: 1.7/edge
+    num_units: 1
+    to:
+    - lxd:0

--- a/development/openstack-base-jammy-zed/charmcraft.yaml
+++ b/development/openstack-base-jammy-zed/charmcraft.yaml
@@ -1,0 +1,16 @@
+type: bundle
+
+parts:
+  bundle:
+    prime:
+      - bundle.yaml
+      - openrc
+      - openrcv3_domain
+      - openrcv3_project
+      - openstack-base-spaces-overlay.yaml
+      - README.md
+      - test-requirements.txt
+      - tests/bundles/bundle.yaml
+      - tests/bundles/overlays/bundle.yaml.j2
+      - tests/tests.yaml
+      - tox.ini

--- a/development/openstack-base-jammy-zed/openrc
+++ b/development/openstack-base-jammy-zed/openrc
@@ -1,0 +1,1 @@
+../shared/openrc

--- a/development/openstack-base-jammy-zed/openrcv3_domain
+++ b/development/openstack-base-jammy-zed/openrcv3_domain
@@ -1,0 +1,1 @@
+../shared/openrcv3_domain

--- a/development/openstack-base-jammy-zed/openrcv3_project
+++ b/development/openstack-base-jammy-zed/openrcv3_project
@@ -1,0 +1,1 @@
+../shared/openrcv3_project

--- a/development/openstack-base-jammy-zed/openstack-base-spaces-overlay.yaml
+++ b/development/openstack-base-jammy-zed/openstack-base-spaces-overlay.yaml
@@ -1,0 +1,1 @@
+../../stable/overlays/openstack-base-spaces-overlay.yaml

--- a/development/openstack-base-jammy-zed/test-requirements.txt
+++ b/development/openstack-base-jammy-zed/test-requirements.txt
@@ -1,0 +1,3 @@
+# zaza
+git+https://github.com/openstack-charmers/zaza.git#egg=zaza
+git+https://github.com/openstack-charmers/zaza-openstack-tests.git#egg=zaza.openstack

--- a/development/openstack-base-jammy-zed/tests/bundles/bundle.yaml
+++ b/development/openstack-base-jammy-zed/tests/bundles/bundle.yaml
@@ -1,0 +1,1 @@
+../../bundle.yaml

--- a/development/openstack-base-jammy-zed/tests/bundles/overlays/local-charm-overlay.yaml.j2
+++ b/development/openstack-base-jammy-zed/tests/bundles/overlays/local-charm-overlay.yaml.j2
@@ -1,0 +1,108 @@
+machines: {}
+applications:
+  ceph-osd:
+    to: []
+    bindings:
+      "": ""
+    storage:
+      osd-devices: 20GB
+  ceph-mon:
+    to: []
+    bindings:
+      "": ""
+  ceph-radosgw:
+    to: []
+    bindings:
+      "": ""
+  cinder:
+    expose: True
+    to: []
+    bindings:
+      "": ""
+  cinder-ceph:
+    bindings:
+      "": ""
+  cinder-mysql-router:
+    bindings:
+      "": ""
+  glance:
+    expose: True
+    to: []
+    bindings:
+      "": ""
+  glance-mysql-router:
+    bindings:
+      "": ""
+  keystone:
+    expose: True
+    to: []
+    bindings:
+      "": ""
+  keystone-mysql-router:
+    bindings:
+      "": ""
+  mysql-innodb-cluster:
+    to: []
+    bindings:
+      "": ""
+  neutron-api:
+    expose: True
+    to: []
+    bindings:
+      "": ""
+  neutron-api-plugin-ovn:
+    bindings:
+      "": ""
+  neutron-mysql-router:
+    bindings:
+      "": ""
+  nova-cloud-controller:
+    expose: True
+    to: []
+    bindings:
+      "": ""
+  nova-compute:
+    annotations:
+    to: []
+    constraints: mem=4G
+    bindings:
+      "": ""
+  nova-mysql-router:
+    bindings:
+      "": ""
+  openstack-dashboard:
+    expose: True
+    to: []
+    bindings:
+      "": ""
+  dashboard-mysql-router:
+    bindings:
+      "": ""
+  ovn-central:
+    to: []
+    bindings:
+      "": ""
+  ovn-chassis:
+    bindings:
+      "": ""
+  placement:
+    to: []
+    bindings:
+      "": ""
+  placement-mysql-router:
+    bindings:
+      "": ""
+  rabbitmq-server:
+    to: []
+    bindings:
+      "": ""
+  ntp:
+    bindings:
+      "": ""
+  vault:
+    to: []
+    bindings:
+      "": ""
+  vault-mysql-router:
+    bindings:
+      "": ""

--- a/development/openstack-base-jammy-zed/tests/tests.yaml
+++ b/development/openstack-base-jammy-zed/tests/tests.yaml
@@ -1,0 +1,32 @@
+configure:
+ - zaza.openstack.charm_tests.vault.setup.auto_initialize_no_validation
+ - zaza.openstack.charm_tests.keystone.setup.add_demo_user
+ - zaza.openstack.charm_tests.nova.setup.create_flavors
+ - zaza.openstack.charm_tests.nova.setup.manage_ssh_key
+ - zaza.openstack.charm_tests.neutron.setup.basic_overcloud_network
+ - zaza.openstack.charm_tests.glance.setup.add_lts_image
+tests:
+  - zaza.openstack.charm_tests.nova.tests.LTSGuestCreateTest
+target_deploy_status:
+  neutron-api-plugin-ovn:
+    workload-status: waiting
+    workload-status-message: "'certificates' awaiting server certificate data, 'ovsdb-cms' incomplete"
+  ovn-central:
+    workload-status: waiting
+    workload-status-message: "'ovsdb-peer' incomplete, 'certificates' awaiting server certificate data"
+  ovn-chassis:
+    workload-status: waiting
+    workload-status-message: "'certificates' awaiting server certificate data"
+  vault:
+    workload-status: blocked
+    workload-status-message: Vault needs to be initialized
+  ntp:
+    workload-status: active
+    workload-status-message: "chrony: Ready"
+gate_bundles:
+  - bundle
+smoke_bundles:
+  - bundle
+tests_options:
+  force_deploy:
+    - bundle

--- a/development/openstack-base-jammy-zed/tox.ini
+++ b/development/openstack-base-jammy-zed/tox.ini
@@ -1,0 +1,1 @@
+../shared/tox.ini

--- a/development/openstack-base-kinetic-zed/README.md
+++ b/development/openstack-base-kinetic-zed/README.md
@@ -1,0 +1,369 @@
+# Basic OpenStack cloud
+
+**TESTING ONLY - This is a development bundle.** See the `stable` directory for
+the stable bundles.
+
+This `openstack-base` bundle deploys a base OpenStack cloud. Its major elements
+include:
+
+* Ubuntu 22.10 (Kinetic)
+* OpenStack Zed
+* Ceph Quincy
+
+Cloud services consist of Compute, Network, Block Storage, Object Storage,
+Identity, Image, and Dashboard.
+
+> **Note**: Modifications will typically need to be made to this bundle for it
+  to work in your environment.
+
+## Requirements
+
+The bundle is primarily designed to work with [MAAS][maas] as a backing cloud
+for Juju.
+
+The MAAS cluster must have a minimum of four nodes:
+
+* one for the Juju controller, with at least 1 CPU and 4 GiB memory
+
+* three (ideally identical) for the actual cloud, with minimum resources
+  being:
+
+    * 8 GiB memory
+    * enough CPU cores to support your workload
+    * two disks
+    * two cabled network interfaces
+
+  The first disk is used for the node's operating system, and the second is for
+  Ceph storage.
+
+  The first network interface is used for communication between cloud services
+  (East/West traffic), and the second is for network traffic between the cloud
+  and all external networks (North/South traffic).
+
+> **Note**: The smaller controller node can be targeted via Juju
+  [constraints][juju-constraints-controller] at controller-creation time.
+
+## Topology
+
+* 3 MAAS nodes, with each hosting one of the following:
+    * Ceph storage
+    * Nova Compute
+    * NTP
+
+* LXD containers for the following (distributed among the 3 MAAS nodes):
+    * Ceph monitors (x3)
+    * Ceph RADOS Gateway
+    * Cinder
+    * Glance
+    * Horizon
+    * Keystone
+    * MySQL8 (x3)
+    * Neutron
+    * Nova Cloud Controller
+    * OVN (x3)
+    * Placement
+    * RabbitMQ
+    * Vault
+
+## Download the bundle
+
+If not already done, clone the [openstack-bundles][openstack-bundles]
+repository:
+
+    git clone https://github.com/openstack-charmers/openstack-bundles
+
+The stable and development bundles are found under the `stable/openstack-base`
+and `development` directories respectively.
+
+Overlay bundles are available under `stable/overlays`. See the Juju
+documentation on [overlay bundles][juju-overlays].
+
+## Modify the bundle
+
+If using the stable openstack-base bundle, the file to modify is
+`./stable/openstack-base/bundle.yaml`.
+
+> **Tip**: Keep the master branch of the repository pristine and create a
+  working branch to contain your modifications.
+
+A `variables:` section is used for conveniently setting values in one place.
+The third column contains the actual values.
+
+    variables:
+      openstack-origin:    &openstack-origin     distro
+      data-port:           &data-port            br-ex:eno2
+      worker-multiplier:   &worker-multiplier    0.25
+      osd-devices:         &osd-devices          /dev/sdb /dev/vdb
+      expected-osd-count:  &expected-osd-count   3
+      expected-mon-count:  &expected-mon-count   3
+
+See the [Install OpenStack][cdg-install-openstack] page in the [OpenStack
+Charms Deployment Guide][cdg] for help on understanding the variables (the
+first column).
+
+### Network spaces
+
+If you're using MAAS and it contains network spaces you will need to bind them
+to the applications being deployed. One way of doing this is with the
+`openstack-base-spaces-overlay.yaml` overlay bundle. Like the main bundle file,
+it will likely require tailoring:
+
+    variables:
+      public-space:        &public-space         public-space
+
+See the Juju documentation on [network spaces][juju-spaces].
+
+### Containerless
+
+If you do not want to run containers you will need to undo the placement
+directives that point to containers. One way of doing this is with the
+`openstack-base-virt-overlay.yaml` overlay bundle.
+
+## MAAS cloud, Juju controller, and model
+
+Ensure that the MAAS cluster has been added to Juju as a cloud and that a Juju
+controller has been created for that cloud. See the Juju documentation for
+guidance: [Using MAAS with Juju][juju-and-maas].
+
+Assuming the controller is called 'maas-controller', create a model called,
+say, 'openstack' and give it the appropriate default series (e.g. jammy):
+
+    juju add-model -c maas-controller --config default-series=jammy openstack
+
+Now ensure that the new model is the current model:
+
+    juju switch maas-controller:openstack
+
+## Deploy the cloud
+
+To install OpenStack, if you're using the spaces overlay:
+
+    juju deploy ./bundle.yaml --overlay ./openstack-base-spaces-overlay.yaml
+
+Otherwise, simply do:
+
+    juju deploy ./bundle.yaml
+
+If you're using a custom overlay (to override elements in earlier bundles)
+simply append it to the command:
+
+    juju deploy ./bundle.yaml --overlay ./custom-overlay.yaml
+    juju deploy ./bundle.yaml --overlay ./openstack-base-spaces-overlay.yaml --overlay ./custom-overlay.yaml
+
+> **Note**: Here it is assumed, for the sake of brevity, that the YAML files
+  are in the current working directory.
+
+### Issue TLS certificates
+
+This bundle uses Vault to issue TLS certificates to services, and some
+post-deployment steps are needed in order for it to work. Failure to complete
+them, for example, will leave the OVN deployment with the following message (in
+`juju status`):
+
+    'ovsdb-*' incomplete, 'certificates' awaiting server certificate data
+
+See to the [Vault charm README][vault-charm-post-deploy] for instructions.
+
+## Install the OpenStack clients
+
+You'll need the OpenStack clients in order to manage your cloud from the
+command line. Install them now:
+
+    sudo snap install openstackclients --classic
+
+## Access the cloud
+
+Confirm that you can access the cloud from the command line:
+
+    source ~/openstack-bundles/stable/openstack-base/openrc
+    openstack service list
+
+You should get a listing of all registered cloud services.
+
+## Import an image
+
+You'll need to import an image into Glance in order to create instances.
+
+First download a boot image, like Focal amd64:
+
+    curl http://cloud-images.ubuntu.com/focal/current/focal-server-cloudimg-amd64.img \
+       --output ~/cloud-images/focal-amd64.img
+
+Now import the image and call it 'focal-amd64':
+
+    openstack image create --public --container-format bare \
+       --disk-format qcow2 --file ~/cloud-images/focal-amd64.img \
+       focal-amd64
+
+Images for other Ubuntu releases and architectures can be obtained in a similar
+way.
+
+For the ARM 64-bit (arm64) architecture you will need to configure the image to
+boot in UEFI mode:
+
+    curl http://cloud-images.ubuntu.com/focal/current/focal-server-cloudimg-amd64.img \
+       --output ~/cloud-images/focal-arm64.img
+
+    openstack image create --public --container-format bare \
+       --disk-format qcow2 --property hw_firmware_type=uefi \
+       --file ~/cloud-images/focal-arm64.img \
+       focal-arm64
+
+## Configure networking
+
+For the purposes of a quick test, we'll set up an external network and a
+shared router ('provider-router') that will be used by all tenants for public
+access to instances.
+
+For an example private cloud, create a network ('ext_net'):
+
+    openstack network create --external \
+       --provider-network-type flat --provider-physical-network physnet1 \
+       ext_net
+
+When creating the external subnet ('ext_subnet') the actual values used will
+depend on the environment that the second network interface (on all nodes) is
+connected to:
+
+    openstack subnet create --network ext_net --no-dhcp \
+       --gateway 10.0.0.1 --subnet-range 10.0.0.0/21 \
+       --allocation-pool start=10.0.0.10,end=10.0.0.200 \
+       ext_subnet
+
+> **Note**: For a public cloud the ports would be connected to a publicly
+  addressable part of the internet.
+
+We'll also need an internal network ('int_net'), subnet ('int_subnet'), and
+router ('provider-router'):
+
+    openstack network create int_net
+
+    openstack subnet create --network int_net --dns-nameserver 8.8.8.8 \
+       --gateway 192.168.0.1 --subnet-range 192.168.0.0/24 \
+       --allocation-pool start=192.168.0.10,end=192.168.0.200 \
+       int_subnet
+
+    openstack router create provider-router
+    openstack router set --external-gateway ext_net provider-router
+    openstack router add subnet provider-router int_subnet
+
+See the [Neutron documentation][openstack-neutron] for more information.
+
+## Create a flavor
+
+Create at least one flavor to define a hardware profile for new instances. Here
+we create one called 'm1.small':
+
+    openstack flavor create --ram 2048 --disk 20 --ephemeral 20 m1.small
+
+Make sure that your MAAS nodes can accommodate the flavor's resources.
+
+## Import an SSH keypair
+
+An SSH keypair needs to be imported into the cloud in order to access your
+instances.
+
+Generate one first if you do not yet have one. This command creates a
+passphraseless keypair (remove the `-N` option to avoid that):
+
+    ssh-keygen -q -N '' -f ~/cloud-keys/id_mykey
+
+To import a keypair:
+
+    openstack keypair create --public-key ~/cloud-keys/id_mykey.pub mykey
+
+## Configure security groups
+
+To allow ICMP (ping) and SSH traffic to flow to cloud instances create
+corresponding rules for each existing security group:
+
+    for i in $(openstack security group list | awk '/default/{ print $2 }'); do
+       openstack security group rule create $i --protocol icmp --remote-ip 0.0.0.0/0;
+       openstack security group rule create $i --protocol tcp --remote-ip 0.0.0.0/0 --dst-port 22;
+    done
+
+You only need to perform this step once.
+
+## Create an instance
+
+Create a Focal amd64 instance called 'focal-1':
+
+    openstack server create --image focal-amd64 --flavor m1.small \
+       --key-name mykey --network int_net \
+        focal-1
+
+## Assign a floating IP address
+
+Request and assign a floating IP address to the new instance:
+
+    FLOATING_IP=$(openstack floating ip create -f value -c floating_ip_address ext_net)
+    openstack server add floating ip focal-1 $FLOATING_IP
+
+## Log in to an instance
+
+Log in to the new instance:
+
+    ssh -i ~/cloud-keys/id_mykey ubuntu@$FLOATING_IP
+
+The below commands are a good start to troubleshooting if something goes wrong:
+
+    openstack console log show focal-1
+    openstack server show focal-1
+
+## Access the cloud dashboard
+
+To access the dashboard (Horizon) first obtain its IP address:
+
+    juju status --format=yaml openstack-dashboard | grep public-address | awk '{print $2}' | head -1
+
+In this example, the address is '10.0.0.30'.
+
+The password can be queried from Keystone:
+
+    juju run --unit keystone/leader leader-get admin_passwd
+
+The dashboard URL then becomes:
+
+**http://10.0.0.30/horizon**
+
+The final credentials needed to log in are:
+
+<!-- There are two spaces at the end of the next two lines -->
+
+User Name: **admin**  
+Password: ********************  
+Domain: **admin_domain**
+
+### VM consoles
+
+Enable a remote access protocol such as `novnc` (or `spice`) if you want to
+connect to VM consoles from within the dashboard:
+
+    juju config nova-cloud-controller console-access-protocol=novnc
+
+## Further reading
+
+The below resources are recommended for further reading:
+
+* [What is OpenStack?]: for an overview of the OpenStack project
+* [OpenStack Administrator Guides][openstack-admin-guides]: for upstream
+  OpenStack administrative help
+* [OpenStack Charms Deployment Guide][cdg]: for charm usage information
+
+<!-- LINKS -->
+
+[maas]: http://maas.io/docs
+[OpenStack Neutron]: http://docs.openstack.org/admin-guide-cloud/content/ch_networking.html
+[OpenStack Admin Guide]: http://docs.openstack.org/user-guide-admin/content
+[Ubuntu Cloud Images]: http://cloud-images.ubuntu.com/focal/current/
+[cdg]: https://docs.openstack.org/project-deploy-guide/charm-deployment-guide/yoga/
+[cdg-install-openstack]: https://docs.openstack.org/project-deploy-guide/charm-deployment-guide/yoga/install-openstack.html
+[openstack-bundles]: https://github.com/openstack-charmers/openstack-bundles
+[juju-overlays]: https://jaas.ai/docs/charm-bundles#heading--overlay-bundles
+[juju-spaces]: https://jaas.ai/docs/spaces
+[juju-constraints-controller]: https://jaas.ai/docs/constraints#heading--setting-constraints-for-a-controller
+[juju-and-maas]: https://jaas.ai/docs/maas-cloud
+[vault-charm-post-deploy]: https://opendev.org/openstack/charm-vault/src/branch/master/src/README.md#post-deployment-tasks
+[openstack-neutron]: https://docs.openstack.org/neutron/
+[openstack-admin-guides]: http://docs.openstack.org/admin
+[What is OpenStack?]: https://ubuntu.com/openstack/what-is-openstack

--- a/development/openstack-base-kinetic-zed/bundle.yaml
+++ b/development/openstack-base-kinetic-zed/bundle.yaml
@@ -1,0 +1,406 @@
+local_overlay_enabled: False
+
+# Please refer to the OpenStack Charms Deployment Guide for more information.
+# https://docs.openstack.org/project-deploy-guide/charm-deployment-guide
+#
+# NOTE: Please review the value for the configuration option
+#       `bridge-interface-mappings` for the `ovn-chassis` charm (see `data-port` variable).
+#       Refer to the [Open Virtual Network (OVN)](https://docs.openstack.org/project-deploy-guide/charm-deployment-guide/latest/app-ovn.html)
+#       section of the [OpenStack Charms Deployment Guide](https://docs.openstack.org/project-deploy-guide/charm-deployment-guide/latest/)
+#       for more information.
+name: openstack-base
+series: kinetic
+variables:
+  openstack-origin: &openstack-origin distro
+  openstack-charm-channel: &openstack-charm-channel zed/edge
+  ovn-charm-channel: &ovn-charm-channel 22.09/edge
+  ceph-charm-channel: &ceph-charm-channel quincy/edge
+  mysql-charm-channel: &mysql-charm-channel 8.0/edge
+  data-port: &data-port to-be-set
+  osd-devices: &osd-devices /dev/sdb /dev/vdb
+  expected-osd-count: &expected-osd-count 3
+  expected-mon-count: &expected-mon-count 3
+machines:
+  '0':
+  '1':
+  '2':
+relations:
+- - nova-compute:amqp
+  - rabbitmq-server:amqp
+- - nova-cloud-controller:identity-service
+  - keystone:identity-service
+- - glance:identity-service
+  - keystone:identity-service
+- - neutron-api:identity-service
+  - keystone:identity-service
+- - neutron-api:amqp
+  - rabbitmq-server:amqp
+- - glance:amqp
+  - rabbitmq-server:amqp
+- - nova-cloud-controller:image-service
+  - glance:image-service
+- - nova-compute:image-service
+  - glance:image-service
+- - nova-cloud-controller:cloud-compute
+  - nova-compute:cloud-compute
+- - nova-cloud-controller:amqp
+  - rabbitmq-server:amqp
+- - openstack-dashboard:identity-service
+  - keystone:identity-service
+- - nova-cloud-controller:neutron-api
+  - neutron-api:neutron-api
+- - cinder:image-service
+  - glance:image-service
+- - cinder:amqp
+  - rabbitmq-server:amqp
+- - cinder:identity-service
+  - keystone:identity-service
+- - cinder:cinder-volume-service
+  - nova-cloud-controller:cinder-volume-service
+- - cinder-ceph:storage-backend
+  - cinder:storage-backend
+- - ceph-mon:client
+  - nova-compute:ceph
+- - nova-compute:ceph-access
+  - cinder-ceph:ceph-access
+- - ceph-mon:client
+  - cinder-ceph:ceph
+- - ceph-mon:client
+  - glance:ceph
+- - ceph-osd:mon
+  - ceph-mon:osd
+- - ntp:juju-info
+  - nova-compute:juju-info
+- - ceph-radosgw:mon
+  - ceph-mon:radosgw
+- - ceph-radosgw:identity-service
+  - keystone:identity-service
+- - placement:identity-service
+  - keystone:identity-service
+- - placement:placement
+  - nova-cloud-controller:placement
+- - keystone:shared-db
+  - keystone-mysql-router:shared-db
+- - cinder:shared-db
+  - cinder-mysql-router:shared-db
+- - glance:shared-db
+  - glance-mysql-router:shared-db
+- - nova-cloud-controller:shared-db
+  - nova-mysql-router:shared-db
+- - neutron-api:shared-db
+  - neutron-mysql-router:shared-db
+- - openstack-dashboard:shared-db
+  - dashboard-mysql-router:shared-db
+- - placement:shared-db
+  - placement-mysql-router:shared-db
+- - vault:shared-db
+  - vault-mysql-router:shared-db
+- - keystone-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - cinder-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - nova-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - glance-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - neutron-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - dashboard-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - placement-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - vault-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - neutron-api-plugin-ovn:neutron-plugin
+  - neutron-api:neutron-plugin-api-subordinate
+- - ovn-central:certificates
+  - vault:certificates
+- - ovn-central:ovsdb-cms
+  - neutron-api-plugin-ovn:ovsdb-cms
+- - neutron-api:certificates
+  - vault:certificates
+- - ovn-chassis:nova-compute
+  - nova-compute:neutron-plugin
+- - ovn-chassis:certificates
+  - vault:certificates
+- - ovn-chassis:ovsdb
+  - ovn-central:ovsdb
+- - vault:certificates
+  - neutron-api-plugin-ovn:certificates
+- - vault:certificates
+  - cinder:certificates
+- - vault:certificates
+  - glance:certificates
+- - vault:certificates
+  - keystone:certificates
+- - vault:certificates
+  - nova-cloud-controller:certificates
+- - vault:certificates
+  - openstack-dashboard:certificates
+- - vault:certificates
+  - placement:certificates
+- - vault:certificates
+  - ceph-radosgw:certificates
+- - vault:certificates
+  - mysql-innodb-cluster:certificates
+applications:
+  ceph-mon:
+    annotations:
+      gui-x: '790'
+      gui-y: '1540'
+    charm: ch:ceph-mon
+    channel: *ceph-charm-channel
+    num_units: 3
+    options:
+      expected-osd-count: *expected-osd-count
+      monitor-count: *expected-mon-count
+      source: *openstack-origin
+    to:
+    - lxd:0
+    - lxd:1
+    - lxd:2
+  ceph-osd:
+    annotations:
+      gui-x: '1065'
+      gui-y: '1540'
+    charm: ch:ceph-osd
+    channel: *ceph-charm-channel
+    num_units: 3
+    options:
+      osd-devices: *osd-devices
+      source: *openstack-origin
+    to:
+    - '0'
+    - '1'
+    - '2'
+  ceph-radosgw:
+    annotations:
+      gui-x: '850'
+      gui-y: '900'
+    charm: ch:ceph-radosgw
+    channel: *ceph-charm-channel
+    num_units: 1
+    options:
+      source: *openstack-origin
+    to:
+    - lxd:0
+  cinder-mysql-router:
+    annotations:
+      gui-x: '900'
+      gui-y: '1400'
+    charm: ch:mysql-router
+    channel: *mysql-charm-channel
+  cinder:
+    annotations:
+      gui-x: '980'
+      gui-y: '1270'
+    charm: ch:cinder
+    channel: *openstack-charm-channel
+    num_units: 1
+    options:
+      block-device: None
+      glance-api-version: 2
+      openstack-origin: *openstack-origin
+    to:
+    - lxd:1
+  cinder-ceph:
+    annotations:
+      gui-x: '1120'
+      gui-y: '1400'
+    charm: ch:cinder-ceph
+    channel: *openstack-charm-channel
+    num_units: 0
+  glance-mysql-router:
+    annotations:
+      gui-x: '-290'
+      gui-y: '1400'
+    charm: ch:mysql-router
+    channel: *mysql-charm-channel
+  glance:
+    annotations:
+      gui-x: '-230'
+      gui-y: '1270'
+    charm: ch:glance
+    channel: *openstack-charm-channel
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+    to:
+    - lxd:2
+  keystone-mysql-router:
+    annotations:
+      gui-x: '230'
+      gui-y: '1400'
+    charm: ch:mysql-router
+    channel: *mysql-charm-channel
+  keystone:
+    annotations:
+      gui-x: '300'
+      gui-y: '1270'
+    charm: ch:keystone
+    channel: *openstack-charm-channel
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+    to:
+    - lxd:0
+  neutron-mysql-router:
+    annotations:
+      gui-x: '505'
+      gui-y: '1385'
+    charm: ch:mysql-router
+    channel: *mysql-charm-channel
+  neutron-api-plugin-ovn:
+    annotations:
+      gui-x: '690'
+      gui-y: '1385'
+    charm: ch:neutron-api-plugin-ovn
+    channel: *openstack-charm-channel
+  neutron-api:
+    annotations:
+      gui-x: '580'
+      gui-y: '1270'
+    charm: ch:neutron-api
+    channel: *openstack-charm-channel
+    num_units: 1
+    options:
+      neutron-security-groups: true
+      flat-network-providers: physnet1
+      openstack-origin: *openstack-origin
+    to:
+    - lxd:1
+  placement-mysql-router:
+    annotations:
+      gui-x: '1320'
+      gui-y: '1385'
+    charm: ch:mysql-router
+    channel: *mysql-charm-channel
+  placement:
+    annotations:
+      gui-x: '1320'
+      gui-y: '1270'
+    charm: ch:placement
+    channel: *openstack-charm-channel
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+    to:
+    - lxd:2
+  nova-mysql-router:
+    annotations:
+      gui-x: '-30'
+      gui-y: '1385'
+    charm: ch:mysql-router
+    channel: *mysql-charm-channel
+  nova-cloud-controller:
+    annotations:
+      gui-x: '35'
+      gui-y: '1270'
+    charm: ch:nova-cloud-controller
+    channel: *openstack-charm-channel
+    num_units: 1
+    options:
+      network-manager: Neutron
+      openstack-origin: *openstack-origin
+    to:
+    - lxd:0
+  nova-compute:
+    annotations:
+      gui-x: '190'
+      gui-y: '890'
+    charm: ch:nova-compute
+    channel: *openstack-charm-channel
+    num_units: 3
+    options:
+      config-flags: default_ephemeral_format=ext4
+      enable-live-migration: true
+      enable-resize: true
+      migration-auth-type: ssh
+      openstack-origin: *openstack-origin
+    to:
+    - '0'
+    - '1'
+    - '2'
+  ntp:
+    annotations:
+      gui-x: '315'
+      gui-y: '1030'
+    charm: ch:ntp
+    num_units: 0
+  dashboard-mysql-router:
+    annotations:
+      gui-x: '510'
+      gui-y: '1030'
+    charm: ch:mysql-router
+    channel: *mysql-charm-channel
+  openstack-dashboard:
+    annotations:
+      gui-x: '585'
+      gui-y: '900'
+    charm: ch:openstack-dashboard
+    channel: *openstack-charm-channel
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+    to:
+    - lxd:1
+  rabbitmq-server:
+    annotations:
+      gui-x: '300'
+      gui-y: '1550'
+    charm: ch:rabbitmq-server
+    channel: 3.9/edge
+    num_units: 1
+    to:
+    - lxd:2
+  mysql-innodb-cluster:
+    annotations:
+      gui-x: '535'
+      gui-y: '1550'
+    charm: ch:mysql-innodb-cluster
+    channel: *mysql-charm-channel
+    num_units: 3
+    to:
+    - lxd:0
+    - lxd:1
+    - lxd:2
+  ovn-central:
+    annotations:
+      gui-x: '70'
+      gui-y: '1550'
+    charm: ch:ovn-central
+    channel: *ovn-charm-channel
+    num_units: 3
+    options:
+      source: *openstack-origin
+    to:
+    - lxd:0
+    - lxd:1
+    - lxd:2
+  ovn-chassis:
+    annotations:
+      gui-x: '120'
+      gui-y: '1030'
+    charm: ch:ovn-chassis
+    channel: *ovn-charm-channel
+    # Please update the `bridge-interface-mappings` to values suitable for the
+    # hardware used in your deployment. See the referenced documentation at the
+    # top of this file.
+    options:
+      ovn-bridge-mappings: physnet1:br-ex
+      bridge-interface-mappings: *data-port
+  vault-mysql-router:
+    annotations:
+      gui-x: '1535'
+      gui-y: '1560'
+    charm: ch:mysql-router
+    channel: *mysql-charm-channel
+  vault:
+    annotations:
+      gui-x: '1610'
+      gui-y: '1430'
+    charm: ch:vault
+    channel: 1.7/edge
+    num_units: 1
+    to:
+    - lxd:0

--- a/development/openstack-base-kinetic-zed/charmcraft.yaml
+++ b/development/openstack-base-kinetic-zed/charmcraft.yaml
@@ -1,0 +1,16 @@
+type: bundle
+
+parts:
+  bundle:
+    prime:
+      - bundle.yaml
+      - openrc
+      - openrcv3_domain
+      - openrcv3_project
+      - openstack-base-spaces-overlay.yaml
+      - README.md
+      - test-requirements.txt
+      - tests/bundles/bundle.yaml
+      - tests/bundles/overlays/bundle.yaml.j2
+      - tests/tests.yaml
+      - tox.ini

--- a/development/openstack-base-kinetic-zed/openrc
+++ b/development/openstack-base-kinetic-zed/openrc
@@ -1,0 +1,1 @@
+../shared/openrc

--- a/development/openstack-base-kinetic-zed/openrcv3_domain
+++ b/development/openstack-base-kinetic-zed/openrcv3_domain
@@ -1,0 +1,1 @@
+../shared/openrcv3_domain

--- a/development/openstack-base-kinetic-zed/openrcv3_project
+++ b/development/openstack-base-kinetic-zed/openrcv3_project
@@ -1,0 +1,1 @@
+../shared/openrcv3_project

--- a/development/openstack-base-kinetic-zed/openstack-base-spaces-overlay.yaml
+++ b/development/openstack-base-kinetic-zed/openstack-base-spaces-overlay.yaml
@@ -1,0 +1,1 @@
+../../stable/overlays/openstack-base-spaces-overlay.yaml

--- a/development/openstack-base-kinetic-zed/test-requirements.txt
+++ b/development/openstack-base-kinetic-zed/test-requirements.txt
@@ -1,0 +1,3 @@
+# zaza
+git+https://github.com/openstack-charmers/zaza.git#egg=zaza
+git+https://github.com/openstack-charmers/zaza-openstack-tests.git#egg=zaza.openstack

--- a/development/openstack-base-kinetic-zed/tests/bundles/bundle.yaml
+++ b/development/openstack-base-kinetic-zed/tests/bundles/bundle.yaml
@@ -1,0 +1,1 @@
+../../bundle.yaml

--- a/development/openstack-base-kinetic-zed/tests/bundles/overlays/local-charm-overlay.yaml.j2
+++ b/development/openstack-base-kinetic-zed/tests/bundles/overlays/local-charm-overlay.yaml.j2
@@ -1,0 +1,108 @@
+machines: {}
+applications:
+  ceph-osd:
+    to: []
+    bindings:
+      "": ""
+    storage:
+      osd-devices: 20GB
+  ceph-mon:
+    to: []
+    bindings:
+      "": ""
+  ceph-radosgw:
+    to: []
+    bindings:
+      "": ""
+  cinder:
+    expose: True
+    to: []
+    bindings:
+      "": ""
+  cinder-ceph:
+    bindings:
+      "": ""
+  cinder-mysql-router:
+    bindings:
+      "": ""
+  glance:
+    expose: True
+    to: []
+    bindings:
+      "": ""
+  glance-mysql-router:
+    bindings:
+      "": ""
+  keystone:
+    expose: True
+    to: []
+    bindings:
+      "": ""
+  keystone-mysql-router:
+    bindings:
+      "": ""
+  mysql-innodb-cluster:
+    to: []
+    bindings:
+      "": ""
+  neutron-api:
+    expose: True
+    to: []
+    bindings:
+      "": ""
+  neutron-api-plugin-ovn:
+    bindings:
+      "": ""
+  neutron-mysql-router:
+    bindings:
+      "": ""
+  nova-cloud-controller:
+    expose: True
+    to: []
+    bindings:
+      "": ""
+  nova-compute:
+    annotations:
+    to: []
+    constraints: mem=4G
+    bindings:
+      "": ""
+  nova-mysql-router:
+    bindings:
+      "": ""
+  openstack-dashboard:
+    expose: True
+    to: []
+    bindings:
+      "": ""
+  dashboard-mysql-router:
+    bindings:
+      "": ""
+  ovn-central:
+    to: []
+    bindings:
+      "": ""
+  ovn-chassis:
+    bindings:
+      "": ""
+  placement:
+    to: []
+    bindings:
+      "": ""
+  placement-mysql-router:
+    bindings:
+      "": ""
+  rabbitmq-server:
+    to: []
+    bindings:
+      "": ""
+  ntp:
+    bindings:
+      "": ""
+  vault:
+    to: []
+    bindings:
+      "": ""
+  vault-mysql-router:
+    bindings:
+      "": ""

--- a/development/openstack-base-kinetic-zed/tests/tests.yaml
+++ b/development/openstack-base-kinetic-zed/tests/tests.yaml
@@ -1,0 +1,32 @@
+configure:
+ - zaza.openstack.charm_tests.vault.setup.auto_initialize_no_validation
+ - zaza.openstack.charm_tests.keystone.setup.add_demo_user
+ - zaza.openstack.charm_tests.nova.setup.create_flavors
+ - zaza.openstack.charm_tests.nova.setup.manage_ssh_key
+ - zaza.openstack.charm_tests.neutron.setup.basic_overcloud_network
+ - zaza.openstack.charm_tests.glance.setup.add_lts_image
+tests:
+  - zaza.openstack.charm_tests.nova.tests.LTSGuestCreateTest
+target_deploy_status:
+  neutron-api-plugin-ovn:
+    workload-status: waiting
+    workload-status-message: "'certificates' awaiting server certificate data, 'ovsdb-cms' incomplete"
+  ovn-central:
+    workload-status: waiting
+    workload-status-message: "'ovsdb-peer' incomplete, 'certificates' awaiting server certificate data"
+  ovn-chassis:
+    workload-status: waiting
+    workload-status-message: "'certificates' awaiting server certificate data"
+  vault:
+    workload-status: blocked
+    workload-status-message: Vault needs to be initialized
+  ntp:
+    workload-status: active
+    workload-status-message: "chrony: Ready"
+gate_bundles:
+  - bundle
+smoke_bundles:
+  - bundle
+tests_options:
+  force_deploy:
+    - bundle

--- a/development/openstack-base-kinetic-zed/tox.ini
+++ b/development/openstack-base-kinetic-zed/tox.ini
@@ -1,0 +1,1 @@
+../shared/tox.ini

--- a/development/openstack-telemetry-jammy-zed/README.md
+++ b/development/openstack-telemetry-jammy-zed/README.md
@@ -1,0 +1,9 @@
+# OpenStack Telemetry
+
+*DEV/TEST ONLY*: This unstable, development example bundle extends the basic OpenStack Cloud bundle with Telemetry collection via Ceilometer. See also: [Stable Bundles](https://jujucharms.com/u/openstack-charmers).
+
+Certain configuration options within the bundle may need to be adjusted prior to deployment to fit your particular set of hardware. For example, network device names and block device names can vary, and passwords should be yours.
+
+For full details on the base cloud deployment please refer to the [Basic OpenStack Cloud][] bundle.
+
+[Basic OpenStack Cloud]: http://jujucharms.com/openstack-base

--- a/development/openstack-telemetry-jammy-zed/bundle.yaml
+++ b/development/openstack-telemetry-jammy-zed/bundle.yaml
@@ -1,0 +1,505 @@
+# Please refer to the OpenStack Charms Deployment Guide for more information.
+# https://docs.openstack.org/project-deploy-guide/charm-deployment-guide
+#
+# NOTE: Please review the value for the configuration option
+#       `bridge-interface-mappings` for the `ovn-chassis` charm (see `data-port` variable).
+#       Refer to the [Open Virtual Network (OVN)](https://docs.openstack.org/project-deploy-guide/charm-deployment-guide/latest/app-ovn.html)
+#       section of the [OpenStack Charms Deployment Guide](https://docs.openstack.org/project-deploy-guide/charm-deployment-guide/latest/)
+#       for more information.
+name: openstack-telemetry
+local_overlay_enabled: true
+series: jammy
+variables:
+  openstack-origin: &openstack-origin cloud:jammy-zed
+  openstack-charm-channel: &openstack-charm-channel zed/edge
+  ovn-charm-channel: &ovn-charm-channel 22.03/edge
+  ceph-charm-channel: &ceph-charm-channel quincy/edge
+  mysql-charm-channel: &mysql-charm-channel 8.0/edge
+  data-port: &data-port to-be-set
+  worker-multiplier: &worker-multiplier 0.25
+  osd-devices: &osd-devices /dev/sdb /dev/vdb
+  expected-osd-count: &expected-osd-count 3
+  expected-mon-count: &expected-mon-count 3
+machines:
+  '0':
+    series: jammy
+  '1':
+    series: jammy
+  '2':
+    series: jammy
+relations:
+- - nova-compute:amqp
+  - rabbitmq-server:amqp
+- - nova-cloud-controller:identity-service
+  - keystone:identity-service
+- - glance:identity-service
+  - keystone:identity-service
+- - neutron-api:identity-service
+  - keystone:identity-service
+- - neutron-api:amqp
+  - rabbitmq-server:amqp
+- - glance:amqp
+  - rabbitmq-server:amqp
+- - nova-cloud-controller:image-service
+  - glance:image-service
+- - nova-compute:image-service
+  - glance:image-service
+- - nova-cloud-controller:cloud-compute
+  - nova-compute:cloud-compute
+- - nova-cloud-controller:amqp
+  - rabbitmq-server:amqp
+- - openstack-dashboard:identity-service
+  - keystone:identity-service
+- - nova-cloud-controller:neutron-api
+  - neutron-api:neutron-api
+- - cinder:image-service
+  - glance:image-service
+- - cinder:amqp
+  - rabbitmq-server:amqp
+- - cinder:identity-service
+  - keystone:identity-service
+- - cinder:cinder-volume-service
+  - nova-cloud-controller:cinder-volume-service
+- - cinder-ceph:storage-backend
+  - cinder:storage-backend
+- - ceph-mon:client
+  - nova-compute:ceph
+- - nova-compute:ceph-access
+  - cinder-ceph:ceph-access
+- - ceph-mon:client
+  - cinder-ceph:ceph
+- - ceph-mon:client
+  - glance:ceph
+- - ceph-osd:mon
+  - ceph-mon:osd
+- - ntp:juju-info
+  - nova-compute:juju-info
+- - ceph-radosgw:mon
+  - ceph-mon:radosgw
+- - ceph-radosgw:identity-service
+  - keystone:identity-service
+- - placement
+  - keystone
+- - placement
+  - nova-cloud-controller
+- - keystone:shared-db
+  - keystone-mysql-router:shared-db
+- - cinder:shared-db
+  - cinder-mysql-router:shared-db
+- - glance:shared-db
+  - glance-mysql-router:shared-db
+- - nova-cloud-controller:shared-db
+  - nova-mysql-router:shared-db
+- - neutron-api:shared-db
+  - neutron-mysql-router:shared-db
+- - openstack-dashboard:shared-db
+  - dashboard-mysql-router:shared-db
+- - placement:shared-db
+  - placement-mysql-router:shared-db
+- - vault:shared-db
+  - vault-mysql-router:shared-db
+- - keystone-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - cinder-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - nova-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - glance-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - neutron-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - dashboard-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - placement-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - vault-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - neutron-api-plugin-ovn:neutron-plugin
+  - neutron-api:neutron-plugin-api-subordinate
+- - ovn-central:certificates
+  - vault:certificates
+- - ovn-central:ovsdb-cms
+  - neutron-api-plugin-ovn:ovsdb-cms
+- - neutron-api:certificates
+  - vault:certificates
+- - ovn-chassis:nova-compute
+  - nova-compute:neutron-plugin
+- - ovn-chassis:certificates
+  - vault:certificates
+- - ovn-chassis:ovsdb
+  - ovn-central:ovsdb
+- - vault:certificates
+  - neutron-api-plugin-ovn:certificates
+- - vault:certificates
+  - cinder:certificates
+- - vault:certificates
+  - glance:certificates
+- - vault:certificates
+  - keystone:certificates
+- - vault:certificates
+  - nova-cloud-controller:certificates
+- - vault:certificates
+  - openstack-dashboard:certificates
+- - vault:certificates
+  - placement:certificates
+- - vault:certificates
+  - ceph-radosgw:certificates
+- - vault:certificates
+  - mysql-innodb-cluster:certificates
+- - ceilometer-agent:ceilometer-service
+  - ceilometer:ceilometer-service
+- - ceilometer:identity-notifications
+  - keystone:identity-notifications
+- - ceilometer:identity-credentials
+  - keystone:identity-credentials
+- - vault:certificates
+  - ceilometer:certificates
+- - ceilometer-agent:nova-ceilometer
+  - nova-compute:nova-ceilometer
+- - ceilometer-agent:amqp
+  - rabbitmq-server:amqp
+- - ceilometer:amqp
+  - rabbitmq-server:amqp
+- - aodh-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - aodh:shared-db
+  - aodh-mysql-router:shared-db
+- - aodh:identity-service
+  - keystone:identity-service
+- - aodh:amqp
+  - rabbitmq-server:amqp
+- - gnocchi:storage-ceph
+  - ceph-mon:client
+- - gnocchi-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - gnocchi:shared-db
+  - gnocchi-mysql-router:shared-db
+- - gnocchi:amqp
+  - rabbitmq-server:amqp
+- - gnocchi:coordinator-memcached
+  - memcached:cache
+- - gnocchi:metric-service
+  - ceilometer:metric-service
+- - gnocchi:identity-service
+  - keystone:identity-service
+applications:
+  aodh:
+    annotations:
+      gui-x: '1500'
+      gui-y: '0'
+    charm: ch:aodh
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+    to:
+    - lxd:0
+    channel: *openstack-charm-channel
+  aodh-mysql-router:
+    charm: ch:mysql-router
+    channel: *mysql-charm-channel
+  ceilometer:
+    annotations:
+      gui-x: '1250'
+      gui-y: '0'
+    charm: ch:ceilometer
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+    to:
+    - lxd:2
+    channel: *openstack-charm-channel
+  ceilometer-agent:
+    annotations:
+      gui-x: '1250'
+      gui-y: '500'
+    charm: ch:ceilometer-agent
+    num_units: 0
+    channel: *openstack-charm-channel
+  ceph-mon:
+    annotations:
+      gui-x: '790'
+      gui-y: '1540'
+    charm: ch:ceph-mon
+    num_units: 3
+    options:
+      expected-osd-count: *expected-osd-count
+      monitor-count: *expected-mon-count
+      source: *openstack-origin
+    to:
+    - lxd:0
+    - lxd:1
+    - lxd:2
+    channel: *ceph-charm-channel
+  ceph-osd:
+    annotations:
+      gui-x: '1065'
+      gui-y: '1540'
+    charm: ch:ceph-osd
+    num_units: 3
+    options:
+      osd-devices: *osd-devices
+      source: *openstack-origin
+    to:
+    - '0'
+    - '1'
+    - '2'
+    channel: *ceph-charm-channel
+  ceph-radosgw:
+    annotations:
+      gui-x: '850'
+      gui-y: '900'
+    charm: ch:ceph-radosgw
+    num_units: 1
+    options:
+      source: *openstack-origin
+    to:
+    - lxd:0
+    channel: *ceph-charm-channel
+  cinder-mysql-router:
+    annotations:
+      gui-x: '900'
+      gui-y: '1400'
+    charm: ch:mysql-router
+    channel: *mysql-charm-channel
+  cinder:
+    annotations:
+      gui-x: '980'
+      gui-y: '1270'
+    charm: ch:cinder
+    num_units: 1
+    options:
+      block-device: None
+      glance-api-version: 2
+      worker-multiplier: *worker-multiplier
+      openstack-origin: *openstack-origin
+    to:
+    - lxd:1
+    channel: *openstack-charm-channel
+  cinder-ceph:
+    annotations:
+      gui-x: '1120'
+      gui-y: '1400'
+    charm: ch:cinder-ceph
+    num_units: 0
+    channel: *openstack-charm-channel
+  glance-mysql-router:
+    annotations:
+      gui-x: '-290'
+      gui-y: '1400'
+    charm: ch:mysql-router
+    channel: *mysql-charm-channel
+  glance:
+    annotations:
+      gui-x: '-230'
+      gui-y: '1270'
+    charm: ch:glance
+    num_units: 1
+    options:
+      worker-multiplier: *worker-multiplier
+      openstack-origin: *openstack-origin
+    to:
+    - lxd:2
+    channel: *openstack-charm-channel
+  keystone-mysql-router:
+    annotations:
+      gui-x: '230'
+      gui-y: '1400'
+    charm: ch:mysql-router
+    channel: *mysql-charm-channel
+  keystone:
+    annotations:
+      gui-x: '300'
+      gui-y: '1270'
+    charm: ch:keystone
+    num_units: 1
+    options:
+      worker-multiplier: *worker-multiplier
+      openstack-origin: *openstack-origin
+    to:
+    - lxd:0
+    channel: *openstack-charm-channel
+  neutron-mysql-router:
+    annotations:
+      gui-x: '505'
+      gui-y: '1385'
+    charm: ch:mysql-router
+    channel: *mysql-charm-channel
+  neutron-api-plugin-ovn:
+    annotations:
+      gui-x: '690'
+      gui-y: '1385'
+    charm: ch:neutron-api-plugin-ovn
+    channel: *openstack-charm-channel
+  neutron-api:
+    annotations:
+      gui-x: '580'
+      gui-y: '1270'
+    charm: ch:neutron-api
+    num_units: 1
+    options:
+      neutron-security-groups: true
+      flat-network-providers: physnet1
+      worker-multiplier: *worker-multiplier
+      openstack-origin: *openstack-origin
+    to:
+    - lxd:1
+    channel: *openstack-charm-channel
+  placement-mysql-router:
+    annotations:
+      gui-x: '1320'
+      gui-y: '1385'
+    charm: ch:mysql-router
+    channel: *mysql-charm-channel
+  placement:
+    annotations:
+      gui-x: '1320'
+      gui-y: '1270'
+    charm: ch:placement
+    num_units: 1
+    options:
+      worker-multiplier: *worker-multiplier
+      openstack-origin: *openstack-origin
+    to:
+    - lxd:2
+    channel: *openstack-charm-channel
+  nova-mysql-router:
+    annotations:
+      gui-x: '-30'
+      gui-y: '1385'
+    charm: ch:mysql-router
+    channel: *mysql-charm-channel
+  nova-cloud-controller:
+    annotations:
+      gui-x: '35'
+      gui-y: '1270'
+    charm: ch:nova-cloud-controller
+    num_units: 1
+    options:
+      network-manager: Neutron
+      worker-multiplier: *worker-multiplier
+      openstack-origin: *openstack-origin
+    to:
+    - lxd:0
+    channel: *openstack-charm-channel
+  nova-compute:
+    annotations:
+      gui-x: '190'
+      gui-y: '890'
+    charm: ch:nova-compute
+    num_units: 3
+    options:
+      config-flags: default_ephemeral_format=ext4
+      enable-live-migration: true
+      enable-resize: true
+      migration-auth-type: ssh
+      openstack-origin: *openstack-origin
+    to:
+    - '0'
+    - '1'
+    - '2'
+    channel: *openstack-charm-channel
+  ntp:
+    annotations:
+      gui-x: '315'
+      gui-y: '1030'
+    charm: ch:ntp
+    num_units: 0
+  dashboard-mysql-router:
+    annotations:
+      gui-x: '510'
+      gui-y: '1030'
+    charm: ch:mysql-router
+    channel: *mysql-charm-channel
+  openstack-dashboard:
+    annotations:
+      gui-x: '585'
+      gui-y: '900'
+    charm: ch:openstack-dashboard
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+    to:
+    - lxd:1
+    channel: *openstack-charm-channel
+  rabbitmq-server:
+    annotations:
+      gui-x: '300'
+      gui-y: '1550'
+    charm: ch:rabbitmq-server
+    num_units: 1
+    to:
+    - lxd:2
+    channel: 3.9/edge
+  mysql-innodb-cluster:
+    annotations:
+      gui-x: '535'
+      gui-y: '1550'
+    charm: ch:mysql-innodb-cluster
+    num_units: 3
+    to:
+    - lxd:0
+    - lxd:1
+    - lxd:2
+    channel: *mysql-charm-channel
+  ovn-central:
+    annotations:
+      gui-x: '70'
+      gui-y: '1550'
+    charm: ch:ovn-central
+    num_units: 3
+    options:
+      source: *openstack-origin
+    to:
+    - lxd:0
+    - lxd:1
+    - lxd:2
+    channel: *ovn-charm-channel
+  ovn-chassis:
+    annotations:
+      gui-x: '120'
+      gui-y: '1030'
+    charm: ch:ovn-chassis
+    # Please update the `bridge-interface-mappings` to values suitable for the
+    # hardware used in your deployment. See the referenced documentation at the
+    # top of this file.
+    options:
+      ovn-bridge-mappings: physnet1:br-ex
+      bridge-interface-mappings: *data-port
+    channel: *ovn-charm-channel
+  vault-mysql-router:
+    annotations:
+      gui-x: '1535'
+      gui-y: '1560'
+    charm: ch:mysql-router
+    channel: *mysql-charm-channel
+  vault:
+    annotations:
+      gui-x: '1610'
+      gui-y: '1430'
+    charm: ch:vault
+    channel: 1.7/edge
+    num_units: 1
+    to:
+    - lxd:0
+  gnocchi:
+    annotations:
+      gui-x: '1500'
+      gui-y: '250'
+    num_units: 1
+    charm: ch:gnocchi
+    options:
+      openstack-origin: *openstack-origin
+    to:
+    - lxd:1
+    channel: *openstack-charm-channel
+  gnocchi-mysql-router:
+    charm: ch:mysql-router
+    channel: *mysql-charm-channel
+  memcached:
+    annotations:
+      gui-x: '1500'
+      gui-y: '500'
+    num_units: 1
+    charm: ch:memcached
+    to:
+    - lxd:2

--- a/development/openstack-telemetry-jammy-zed/charmcraft.yaml
+++ b/development/openstack-telemetry-jammy-zed/charmcraft.yaml
@@ -1,0 +1,12 @@
+type: bundle
+
+parts:
+  bundle:
+    prime:
+      - bundle.yaml
+      - openrc
+      - openrcv3_domain
+      - openrcv3_project
+      - openstack-telemetry-spaces-overlay.yaml
+      - README.md
+      - repo-info

--- a/development/openstack-telemetry-jammy-zed/openrc
+++ b/development/openstack-telemetry-jammy-zed/openrc
@@ -1,0 +1,1 @@
+../shared/openrc

--- a/development/openstack-telemetry-jammy-zed/openrcv3_domain
+++ b/development/openstack-telemetry-jammy-zed/openrcv3_domain
@@ -1,0 +1,1 @@
+../shared/openrcv3_domain

--- a/development/openstack-telemetry-jammy-zed/openrcv3_project
+++ b/development/openstack-telemetry-jammy-zed/openrcv3_project
@@ -1,0 +1,1 @@
+../shared/openrcv3_project

--- a/development/openstack-telemetry-jammy-zed/test-requirements.txt
+++ b/development/openstack-telemetry-jammy-zed/test-requirements.txt
@@ -1,0 +1,3 @@
+# zaza
+git+https://github.com/openstack-charmers/zaza.git#egg=zaza
+git+https://github.com/openstack-charmers/zaza-openstack-tests.git#egg=zaza.openstack

--- a/development/openstack-telemetry-jammy-zed/tests/bundles/bundle.yaml
+++ b/development/openstack-telemetry-jammy-zed/tests/bundles/bundle.yaml
@@ -1,0 +1,1 @@
+../../bundle.yaml

--- a/development/openstack-telemetry-jammy-zed/tests/bundles/overlays/bundle.yaml.j2
+++ b/development/openstack-telemetry-jammy-zed/tests/bundles/overlays/bundle.yaml.j2
@@ -1,0 +1,1 @@
+../../../../overlays/openstack-base-virt-overlay.yaml

--- a/development/openstack-telemetry-jammy-zed/tests/tests.yaml
+++ b/development/openstack-telemetry-jammy-zed/tests/tests.yaml
@@ -1,0 +1,32 @@
+configure:
+  - zaza.openstack.charm_tests.vault.setup.auto_initialize_no_validation
+  - zaza.openstack.charm_tests.keystone.setup.add_demo_user
+  - zaza.openstack.charm_tests.nova.setup.create_flavors
+  - zaza.openstack.charm_tests.nova.setup.manage_ssh_key
+  - zaza.openstack.charm_tests.neutron.setup.basic_overcloud_network
+  - zaza.openstack.charm_tests.glance.setup.add_lts_image
+tests:
+  - zaza.openstack.charm_tests.nova.tests.LTSGuestCreateTest
+target_deploy_status:
+  neutron-api-plugin-ovn:
+    workload-status: waiting
+    workload-status-message-prefix: "'certificates' awaiting server certificate data, 'ovsdb-cms' incomplete"
+  ovn-central:
+    workload-status: waiting
+    workload-status-message-prefix: "'ovsdb-peer' incomplete, 'certificates' awaiting server certificate data"
+  ovn-chassis:
+    workload-status: waiting
+    workload-status-message-prefix: "'certificates' awaiting server certificate data"
+  vault:
+    workload-status: blocked
+    workload-status-message-prefix: Vault needs to be initialized
+  ntp:
+    workload-status: active
+    workload-status-message-prefix: "chrony: Ready"
+  ceilometer:
+    workload-status: blocked
+    workload-status-message-prefix: "Run the ceilometer-upgrade action on the leader to initialize ceilometer and gnocchi"
+gate_bundles:
+  - bundle
+smoke_bundles:
+  - bundle

--- a/development/openstack-telemetry-jammy-zed/tox.ini
+++ b/development/openstack-telemetry-jammy-zed/tox.ini
@@ -1,0 +1,1 @@
+../shared/tox.ini

--- a/development/openstack-telemetry-kinetic-zed/README.md
+++ b/development/openstack-telemetry-kinetic-zed/README.md
@@ -1,0 +1,9 @@
+# OpenStack Telemetry
+
+*DEV/TEST ONLY*: This unstable, development example bundle extends the basic OpenStack Cloud bundle with Telemetry collection via Ceilometer. See also: [Stable Bundles](https://jujucharms.com/u/openstack-charmers).
+
+Certain configuration options within the bundle may need to be adjusted prior to deployment to fit your particular set of hardware. For example, network device names and block device names can vary, and passwords should be yours.
+
+For full details on the base cloud deployment please refer to the [Basic OpenStack Cloud][] bundle.
+
+[Basic OpenStack Cloud]: http://jujucharms.com/openstack-base

--- a/development/openstack-telemetry-kinetic-zed/bundle.yaml
+++ b/development/openstack-telemetry-kinetic-zed/bundle.yaml
@@ -1,0 +1,505 @@
+# Please refer to the OpenStack Charms Deployment Guide for more information.
+# https://docs.openstack.org/project-deploy-guide/charm-deployment-guide
+#
+# NOTE: Please review the value for the configuration option
+#       `bridge-interface-mappings` for the `ovn-chassis` charm (see `data-port` variable).
+#       Refer to the [Open Virtual Network (OVN)](https://docs.openstack.org/project-deploy-guide/charm-deployment-guide/latest/app-ovn.html)
+#       section of the [OpenStack Charms Deployment Guide](https://docs.openstack.org/project-deploy-guide/charm-deployment-guide/latest/)
+#       for more information.
+name: openstack-telemetry
+local_overlay_enabled: true
+series: kinetic
+variables:
+  openstack-origin: &openstack-origin distro
+  openstack-charm-channel: &openstack-charm-channel zed/edge
+  ovn-charm-channel: &ovn-charm-channel 22.09/edge
+  ceph-charm-channel: &ceph-charm-channel quincy/edge
+  mysql-charm-channel: &mysql-charm-channel 8.0/edge
+  data-port: &data-port to-be-set
+  worker-multiplier: &worker-multiplier 0.25
+  osd-devices: &osd-devices /dev/sdb /dev/vdb
+  expected-osd-count: &expected-osd-count 3
+  expected-mon-count: &expected-mon-count 3
+machines:
+  '0':
+    series: jammy
+  '1':
+    series: jammy
+  '2':
+    series: jammy
+relations:
+- - nova-compute:amqp
+  - rabbitmq-server:amqp
+- - nova-cloud-controller:identity-service
+  - keystone:identity-service
+- - glance:identity-service
+  - keystone:identity-service
+- - neutron-api:identity-service
+  - keystone:identity-service
+- - neutron-api:amqp
+  - rabbitmq-server:amqp
+- - glance:amqp
+  - rabbitmq-server:amqp
+- - nova-cloud-controller:image-service
+  - glance:image-service
+- - nova-compute:image-service
+  - glance:image-service
+- - nova-cloud-controller:cloud-compute
+  - nova-compute:cloud-compute
+- - nova-cloud-controller:amqp
+  - rabbitmq-server:amqp
+- - openstack-dashboard:identity-service
+  - keystone:identity-service
+- - nova-cloud-controller:neutron-api
+  - neutron-api:neutron-api
+- - cinder:image-service
+  - glance:image-service
+- - cinder:amqp
+  - rabbitmq-server:amqp
+- - cinder:identity-service
+  - keystone:identity-service
+- - cinder:cinder-volume-service
+  - nova-cloud-controller:cinder-volume-service
+- - cinder-ceph:storage-backend
+  - cinder:storage-backend
+- - ceph-mon:client
+  - nova-compute:ceph
+- - nova-compute:ceph-access
+  - cinder-ceph:ceph-access
+- - ceph-mon:client
+  - cinder-ceph:ceph
+- - ceph-mon:client
+  - glance:ceph
+- - ceph-osd:mon
+  - ceph-mon:osd
+- - ntp:juju-info
+  - nova-compute:juju-info
+- - ceph-radosgw:mon
+  - ceph-mon:radosgw
+- - ceph-radosgw:identity-service
+  - keystone:identity-service
+- - placement
+  - keystone
+- - placement
+  - nova-cloud-controller
+- - keystone:shared-db
+  - keystone-mysql-router:shared-db
+- - cinder:shared-db
+  - cinder-mysql-router:shared-db
+- - glance:shared-db
+  - glance-mysql-router:shared-db
+- - nova-cloud-controller:shared-db
+  - nova-mysql-router:shared-db
+- - neutron-api:shared-db
+  - neutron-mysql-router:shared-db
+- - openstack-dashboard:shared-db
+  - dashboard-mysql-router:shared-db
+- - placement:shared-db
+  - placement-mysql-router:shared-db
+- - vault:shared-db
+  - vault-mysql-router:shared-db
+- - keystone-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - cinder-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - nova-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - glance-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - neutron-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - dashboard-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - placement-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - vault-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - neutron-api-plugin-ovn:neutron-plugin
+  - neutron-api:neutron-plugin-api-subordinate
+- - ovn-central:certificates
+  - vault:certificates
+- - ovn-central:ovsdb-cms
+  - neutron-api-plugin-ovn:ovsdb-cms
+- - neutron-api:certificates
+  - vault:certificates
+- - ovn-chassis:nova-compute
+  - nova-compute:neutron-plugin
+- - ovn-chassis:certificates
+  - vault:certificates
+- - ovn-chassis:ovsdb
+  - ovn-central:ovsdb
+- - vault:certificates
+  - neutron-api-plugin-ovn:certificates
+- - vault:certificates
+  - cinder:certificates
+- - vault:certificates
+  - glance:certificates
+- - vault:certificates
+  - keystone:certificates
+- - vault:certificates
+  - nova-cloud-controller:certificates
+- - vault:certificates
+  - openstack-dashboard:certificates
+- - vault:certificates
+  - placement:certificates
+- - vault:certificates
+  - ceph-radosgw:certificates
+- - vault:certificates
+  - mysql-innodb-cluster:certificates
+- - ceilometer-agent:ceilometer-service
+  - ceilometer:ceilometer-service
+- - ceilometer:identity-notifications
+  - keystone:identity-notifications
+- - ceilometer:identity-credentials
+  - keystone:identity-credentials
+- - vault:certificates
+  - ceilometer:certificates
+- - ceilometer-agent:nova-ceilometer
+  - nova-compute:nova-ceilometer
+- - ceilometer-agent:amqp
+  - rabbitmq-server:amqp
+- - ceilometer:amqp
+  - rabbitmq-server:amqp
+- - aodh-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - aodh:shared-db
+  - aodh-mysql-router:shared-db
+- - aodh:identity-service
+  - keystone:identity-service
+- - aodh:amqp
+  - rabbitmq-server:amqp
+- - gnocchi:storage-ceph
+  - ceph-mon:client
+- - gnocchi-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - gnocchi:shared-db
+  - gnocchi-mysql-router:shared-db
+- - gnocchi:amqp
+  - rabbitmq-server:amqp
+- - gnocchi:coordinator-memcached
+  - memcached:cache
+- - gnocchi:metric-service
+  - ceilometer:metric-service
+- - gnocchi:identity-service
+  - keystone:identity-service
+applications:
+  aodh:
+    annotations:
+      gui-x: '1500'
+      gui-y: '0'
+    charm: ch:aodh
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+    to:
+    - lxd:0
+    channel: *openstack-charm-channel
+  aodh-mysql-router:
+    charm: ch:mysql-router
+    channel: *mysql-charm-channel
+  ceilometer:
+    annotations:
+      gui-x: '1250'
+      gui-y: '0'
+    charm: ch:ceilometer
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+    to:
+    - lxd:2
+    channel: *openstack-charm-channel
+  ceilometer-agent:
+    annotations:
+      gui-x: '1250'
+      gui-y: '500'
+    charm: ch:ceilometer-agent
+    num_units: 0
+    channel: *openstack-charm-channel
+  ceph-mon:
+    annotations:
+      gui-x: '790'
+      gui-y: '1540'
+    charm: ch:ceph-mon
+    num_units: 3
+    options:
+      expected-osd-count: *expected-osd-count
+      monitor-count: *expected-mon-count
+      source: *openstack-origin
+    to:
+    - lxd:0
+    - lxd:1
+    - lxd:2
+    channel: *ceph-charm-channel
+  ceph-osd:
+    annotations:
+      gui-x: '1065'
+      gui-y: '1540'
+    charm: ch:ceph-osd
+    num_units: 3
+    options:
+      osd-devices: *osd-devices
+      source: *openstack-origin
+    to:
+    - '0'
+    - '1'
+    - '2'
+    channel: *ceph-charm-channel
+  ceph-radosgw:
+    annotations:
+      gui-x: '850'
+      gui-y: '900'
+    charm: ch:ceph-radosgw
+    num_units: 1
+    options:
+      source: *openstack-origin
+    to:
+    - lxd:0
+    channel: *ceph-charm-channel
+  cinder-mysql-router:
+    annotations:
+      gui-x: '900'
+      gui-y: '1400'
+    charm: ch:mysql-router
+    channel: *mysql-charm-channel
+  cinder:
+    annotations:
+      gui-x: '980'
+      gui-y: '1270'
+    charm: ch:cinder
+    num_units: 1
+    options:
+      block-device: None
+      glance-api-version: 2
+      worker-multiplier: *worker-multiplier
+      openstack-origin: *openstack-origin
+    to:
+    - lxd:1
+    channel: *openstack-charm-channel
+  cinder-ceph:
+    annotations:
+      gui-x: '1120'
+      gui-y: '1400'
+    charm: ch:cinder-ceph
+    num_units: 0
+    channel: *openstack-charm-channel
+  glance-mysql-router:
+    annotations:
+      gui-x: '-290'
+      gui-y: '1400'
+    charm: ch:mysql-router
+    channel: *mysql-charm-channel
+  glance:
+    annotations:
+      gui-x: '-230'
+      gui-y: '1270'
+    charm: ch:glance
+    num_units: 1
+    options:
+      worker-multiplier: *worker-multiplier
+      openstack-origin: *openstack-origin
+    to:
+    - lxd:2
+    channel: *openstack-charm-channel
+  keystone-mysql-router:
+    annotations:
+      gui-x: '230'
+      gui-y: '1400'
+    charm: ch:mysql-router
+    channel: *mysql-charm-channel
+  keystone:
+    annotations:
+      gui-x: '300'
+      gui-y: '1270'
+    charm: ch:keystone
+    num_units: 1
+    options:
+      worker-multiplier: *worker-multiplier
+      openstack-origin: *openstack-origin
+    to:
+    - lxd:0
+    channel: *openstack-charm-channel
+  neutron-mysql-router:
+    annotations:
+      gui-x: '505'
+      gui-y: '1385'
+    charm: ch:mysql-router
+    channel: *mysql-charm-channel
+  neutron-api-plugin-ovn:
+    annotations:
+      gui-x: '690'
+      gui-y: '1385'
+    charm: ch:neutron-api-plugin-ovn
+    channel: *openstack-charm-channel
+  neutron-api:
+    annotations:
+      gui-x: '580'
+      gui-y: '1270'
+    charm: ch:neutron-api
+    num_units: 1
+    options:
+      neutron-security-groups: true
+      flat-network-providers: physnet1
+      worker-multiplier: *worker-multiplier
+      openstack-origin: *openstack-origin
+    to:
+    - lxd:1
+    channel: *openstack-charm-channel
+  placement-mysql-router:
+    annotations:
+      gui-x: '1320'
+      gui-y: '1385'
+    charm: ch:mysql-router
+    channel: *mysql-charm-channel
+  placement:
+    annotations:
+      gui-x: '1320'
+      gui-y: '1270'
+    charm: ch:placement
+    num_units: 1
+    options:
+      worker-multiplier: *worker-multiplier
+      openstack-origin: *openstack-origin
+    to:
+    - lxd:2
+    channel: *openstack-charm-channel
+  nova-mysql-router:
+    annotations:
+      gui-x: '-30'
+      gui-y: '1385'
+    charm: ch:mysql-router
+    channel: *mysql-charm-channel
+  nova-cloud-controller:
+    annotations:
+      gui-x: '35'
+      gui-y: '1270'
+    charm: ch:nova-cloud-controller
+    num_units: 1
+    options:
+      network-manager: Neutron
+      worker-multiplier: *worker-multiplier
+      openstack-origin: *openstack-origin
+    to:
+    - lxd:0
+    channel: *openstack-charm-channel
+  nova-compute:
+    annotations:
+      gui-x: '190'
+      gui-y: '890'
+    charm: ch:nova-compute
+    num_units: 3
+    options:
+      config-flags: default_ephemeral_format=ext4
+      enable-live-migration: true
+      enable-resize: true
+      migration-auth-type: ssh
+      openstack-origin: *openstack-origin
+    to:
+    - '0'
+    - '1'
+    - '2'
+    channel: *openstack-charm-channel
+  ntp:
+    annotations:
+      gui-x: '315'
+      gui-y: '1030'
+    charm: ch:ntp
+    num_units: 0
+  dashboard-mysql-router:
+    annotations:
+      gui-x: '510'
+      gui-y: '1030'
+    charm: ch:mysql-router
+    channel: *mysql-charm-channel
+  openstack-dashboard:
+    annotations:
+      gui-x: '585'
+      gui-y: '900'
+    charm: ch:openstack-dashboard
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+    to:
+    - lxd:1
+    channel: *openstack-charm-channel
+  rabbitmq-server:
+    annotations:
+      gui-x: '300'
+      gui-y: '1550'
+    charm: ch:rabbitmq-server
+    num_units: 1
+    to:
+    - lxd:2
+    channel: 3.9/edge
+  mysql-innodb-cluster:
+    annotations:
+      gui-x: '535'
+      gui-y: '1550'
+    charm: ch:mysql-innodb-cluster
+    num_units: 3
+    to:
+    - lxd:0
+    - lxd:1
+    - lxd:2
+    channel: *mysql-charm-channel
+  ovn-central:
+    annotations:
+      gui-x: '70'
+      gui-y: '1550'
+    charm: ch:ovn-central
+    num_units: 3
+    options:
+      source: *openstack-origin
+    to:
+    - lxd:0
+    - lxd:1
+    - lxd:2
+    channel: *ovn-charm-channel
+  ovn-chassis:
+    annotations:
+      gui-x: '120'
+      gui-y: '1030'
+    charm: ch:ovn-chassis
+    # Please update the `bridge-interface-mappings` to values suitable for the
+    # hardware used in your deployment. See the referenced documentation at the
+    # top of this file.
+    options:
+      ovn-bridge-mappings: physnet1:br-ex
+      bridge-interface-mappings: *data-port
+    channel: *ovn-charm-channel
+  vault-mysql-router:
+    annotations:
+      gui-x: '1535'
+      gui-y: '1560'
+    charm: ch:mysql-router
+    channel: *mysql-charm-channel
+  vault:
+    annotations:
+      gui-x: '1610'
+      gui-y: '1430'
+    charm: ch:vault
+    channel: 1.7/edge
+    num_units: 1
+    to:
+    - lxd:0
+  gnocchi:
+    annotations:
+      gui-x: '1500'
+      gui-y: '250'
+    num_units: 1
+    charm: ch:gnocchi
+    options:
+      openstack-origin: *openstack-origin
+    to:
+    - lxd:1
+    channel: *openstack-charm-channel
+  gnocchi-mysql-router:
+    charm: ch:mysql-router
+    channel: *mysql-charm-channel
+  memcached:
+    annotations:
+      gui-x: '1500'
+      gui-y: '500'
+    num_units: 1
+    charm: ch:memcached
+    to:
+    - lxd:2

--- a/development/openstack-telemetry-kinetic-zed/charmcraft.yaml
+++ b/development/openstack-telemetry-kinetic-zed/charmcraft.yaml
@@ -1,0 +1,12 @@
+type: bundle
+
+parts:
+  bundle:
+    prime:
+      - bundle.yaml
+      - openrc
+      - openrcv3_domain
+      - openrcv3_project
+      - openstack-telemetry-spaces-overlay.yaml
+      - README.md
+      - repo-info

--- a/development/openstack-telemetry-kinetic-zed/openrc
+++ b/development/openstack-telemetry-kinetic-zed/openrc
@@ -1,0 +1,1 @@
+../shared/openrc

--- a/development/openstack-telemetry-kinetic-zed/openrcv3_domain
+++ b/development/openstack-telemetry-kinetic-zed/openrcv3_domain
@@ -1,0 +1,1 @@
+../shared/openrcv3_domain

--- a/development/openstack-telemetry-kinetic-zed/openrcv3_project
+++ b/development/openstack-telemetry-kinetic-zed/openrcv3_project
@@ -1,0 +1,1 @@
+../shared/openrcv3_project

--- a/development/openstack-telemetry-kinetic-zed/test-requirements.txt
+++ b/development/openstack-telemetry-kinetic-zed/test-requirements.txt
@@ -1,0 +1,3 @@
+# zaza
+git+https://github.com/openstack-charmers/zaza.git#egg=zaza
+git+https://github.com/openstack-charmers/zaza-openstack-tests.git#egg=zaza.openstack

--- a/development/openstack-telemetry-kinetic-zed/tests/bundles/bundle.yaml
+++ b/development/openstack-telemetry-kinetic-zed/tests/bundles/bundle.yaml
@@ -1,0 +1,1 @@
+../../bundle.yaml

--- a/development/openstack-telemetry-kinetic-zed/tests/bundles/overlays/bundle.yaml.j2
+++ b/development/openstack-telemetry-kinetic-zed/tests/bundles/overlays/bundle.yaml.j2
@@ -1,0 +1,1 @@
+../../../../overlays/openstack-base-virt-overlay.yaml

--- a/development/openstack-telemetry-kinetic-zed/tests/tests.yaml
+++ b/development/openstack-telemetry-kinetic-zed/tests/tests.yaml
@@ -1,0 +1,32 @@
+configure:
+  - zaza.openstack.charm_tests.vault.setup.auto_initialize_no_validation
+  - zaza.openstack.charm_tests.keystone.setup.add_demo_user
+  - zaza.openstack.charm_tests.nova.setup.create_flavors
+  - zaza.openstack.charm_tests.nova.setup.manage_ssh_key
+  - zaza.openstack.charm_tests.neutron.setup.basic_overcloud_network
+  - zaza.openstack.charm_tests.glance.setup.add_lts_image
+tests:
+  - zaza.openstack.charm_tests.nova.tests.LTSGuestCreateTest
+target_deploy_status:
+  neutron-api-plugin-ovn:
+    workload-status: waiting
+    workload-status-message-prefix: "'certificates' awaiting server certificate data, 'ovsdb-cms' incomplete"
+  ovn-central:
+    workload-status: waiting
+    workload-status-message-prefix: "'ovsdb-peer' incomplete, 'certificates' awaiting server certificate data"
+  ovn-chassis:
+    workload-status: waiting
+    workload-status-message-prefix: "'certificates' awaiting server certificate data"
+  vault:
+    workload-status: blocked
+    workload-status-message-prefix: Vault needs to be initialized
+  ntp:
+    workload-status: active
+    workload-status-message-prefix: "chrony: Ready"
+  ceilometer:
+    workload-status: blocked
+    workload-status-message-prefix: "Run the ceilometer-upgrade action on the leader to initialize ceilometer and gnocchi"
+gate_bundles:
+  - bundle
+smoke_bundles:
+  - bundle

--- a/development/openstack-telemetry-kinetic-zed/tox.ini
+++ b/development/openstack-telemetry-kinetic-zed/tox.ini
@@ -1,0 +1,1 @@
+../shared/tox.ini


### PR DESCRIPTION
This PR adds the following new bundles:

- openstack-telemetry-kinetic-zed
- openstack-base-kinetic-zed
- openstack-telemetry-jammy-zed
- openstack-base-jammy-zed

The most notable differences in comparison with the Yoga bundles are:
- OVN is deployed from the 22.09 track
- Ceph is still deployed from the quincy track
- There are 'variables' at the top of the bundles to change the channels for openstack, ovn, ceph and mysql charms.