### PR TITLE
use NTP charm from charmhub

### DIFF
--- a/stable/openstack-base/bundle.yaml
+++ b/stable/openstack-base/bundle.yaml
@@ -319,7 +319,7 @@ applications:
     annotations:
       gui-x: '315'
       gui-y: '1030'
-    charm: cs:ntp-47
+    charm: ch:ntp
     num_units: 0
   dashboard-mysql-router:
     annotations:


### PR DESCRIPTION
a deployment is fine as of right now, but Juju is dropping cs: support.
Also, cs: makes `juju export-bundle --include-charm-defaults` fail.